### PR TITLE
Fix links in main About page

### DIFF
--- a/manual/antora/modules/ROOT/pages/index.adoc
+++ b/manual/antora/modules/ROOT/pages/index.adoc
@@ -1,3 +1,3 @@
 = About USFM and USX
 
-IMPORTANT: *This is a development site only*. The current USFM and USX documentation sites are available at https://ubsicap.hithub.io/usfm[] and https://ubsicap.hithub.io/usx[]
+IMPORTANT: *This is a development site only*. The current USFM and USX documentation sites are available at https://ubsicap.github.io/usfm[] and https://ubsicap.github.io/usx[]


### PR DESCRIPTION
The links in the main About page go to hithub.io instead of github.io, probably due to a typo. This PR fixes that mistake.