### PR TITLE
Add tags for stress tests

### DIFF
--- a/tests/readme.md
+++ b/tests/readme.md
@@ -34,5 +34,8 @@ included in a file. The following keys are considered to have meaning.
   is `fail` then the data is expected to not pass validation and if there is only a
   origin.sfm and no origin.xml, then the origin.sfm is not expected to parse
   correctly. If it is empty then the result is indeterminate. But ideally it should be set.
- - **tags**. A space separated list of single word tags to allow
-   subcategorisation of tests.
+ - **tags**. A space separated list of single word tags to allow sub-categorisation of tests.
+   Currently, the defined tags are:
+   - `exemplar`: short example if use of a marker within a particular context or not.
+   - `stress`: Indicates lots of data; trying to break things.
+   - `sample`: A complete book or chapters. Denotes non-truncated real world examples.

--- a/tests/samples-from-wild/alignment/metadata.xml
+++ b/tests/samples-from-wild/alignment/metadata.xml
@@ -2,5 +2,5 @@
 <test-metadata>
         <description>AMT alignment export file</description>
         <validated>pass</validated>
-        <tags></tags>
+        <tags>stress sample</tags>
 </test-metadata>

--- a/tests/usfmjsTests/45-ACT.ugnt.oldformat/metadata.xml
+++ b/tests/usfmjsTests/45-ACT.ugnt.oldformat/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <test-metadata>
-        <description>  preserves k markers and footnotes in 45-ACT.ugnt.oldformat</description>
+        <description>preserves k markers and footnotes in 45-ACT.ugnt.oldformat</description>
         <validated>pass</validated>
-        <tags></tags>
+        <tags>stress sample</tags>
 </test-metadata>

--- a/tests/usfmjsTests/45-ACT.ugnt/metadata.xml
+++ b/tests/usfmjsTests/45-ACT.ugnt/metadata.xml
@@ -2,5 +2,5 @@
 <test-metadata>
         <description>  preserves k markers and footnotes in 45-ACT.ugnt</description>
         <validated>pass</validated>
-        <tags></tags>
+        <tags>stress sample</tags>
 </test-metadata>


### PR DESCRIPTION
## Background
There are a few tests that have large USFM files and may slow down a full test run.

## Improvement
These have tests have now been tagged as `stress` so that testers can optionally skip them as part of their local testing. Moreover, this PR adds documentation for some predefined tags to start with.