### PR TITLE
Bugfix in USJ: Optbreak b distinction

### DIFF
--- a/python/lib/usfmtc/usjproc.py
+++ b/python/lib/usfmtc/usjproc.py
@@ -13,8 +13,6 @@ def usxtousj(input_usx_elmt):
     attribs = dict(input_usx_elmt.attrib)
     tag = None
     if "style" in attribs:
-        if attribs["style"] == 'b':
-            key = "optbreak"
         tag = attribs['style']
         del attribs['style']
     if "vid" in attribs:
@@ -45,7 +43,7 @@ def usxtousj(input_usx_elmt):
                 pass
         if child.tail and child.tail.strip() != "":
             out_obj['content'].append(child.tail.strip())
-    if  (key in ["chapter", "verse", "optbreak", "ms"] or tag in ["va", "ca"])\
+    if  (key in ["chapter", "verse", "optbreak", "ms"] or tag in ["va", "ca", "b"])\
          and out_obj['content'] == []:
         del out_obj['content']
     if "eid" in out_obj and key in ['verse', 'chapter']:

--- a/python/scripts/usj4testsuite.py
+++ b/python/scripts/usj4testsuite.py
@@ -6,7 +6,7 @@ import usx2usj
 usx_paths = glob.glob('tests/*/*/origin.xml') + glob.glob('tests/*/*/*/origin.xml')
 
 problem_usxs = [
-    'tests/usfmjsTests/esb/origin.xml',  # last verse text given outside of paragraph. 
+    # 'tests/biblica/BlankLinesWithFigures/origin.xml', # fig within b. Shouldn't b always be empty?
 ]
 
 for usx_path in usx_paths:
@@ -26,7 +26,7 @@ usfm_paths = glob.glob('tests/*/*/origin.usfm') + glob.glob('tests/*/*/*/origin.
 print(f"USFM samples: {len(usfm_paths)}")
 print(f"USX samples: {len(usx_paths)}")
 
-usj_paths = glob.glob('tests/*/*/origin-usj.json') + \
-            glob.glob('tests/*/*/*/origin-usj.json')
+usj_paths = glob.glob('tests/*/*/origin.json') + \
+            glob.glob('tests/*/*/*/origin.json')
 print(f"USJ samples generated only for: {len(usj_paths)}")
 print("(Converted only where USX was present and did not have elements with status='invalid' or other issues in it.)")

--- a/python/scripts/usx2usj.py
+++ b/python/scripts/usx2usj.py
@@ -2,7 +2,7 @@ import argparse
 import json
 from lxml import etree
 
-VERSION_NUM = "0.2.0"
+VERSION_NUM = "0.2.1"
 SPEC_NAME = "USJ" # for Unified Scripture JSON
 
 def convert_usx(input_usx_elmt):

--- a/python/scripts/usx2usj.py
+++ b/python/scripts/usx2usj.py
@@ -17,8 +17,6 @@ def convert_usx(input_usx_elmt):
     attribs = dict(input_usx_elmt.attrib)
     tag = None
     if "style" in attribs:
-        if attribs["style"] == 'b':
-            key = "optbreak"
         tag = attribs['style']
         del attribs['style']
     if "vid" in attribs:
@@ -50,7 +48,7 @@ def convert_usx(input_usx_elmt):
                 pass
         if child.tail and child.tail.strip() != "":
             out_obj['content'].append(child.tail.strip())
-    if  (key in ["chapter", "verse", "optbreak", "ms"] or tag in ["va", "ca"])\
+    if  (key in ["chapter", "verse", "optbreak", "ms"] or tag in ["va", "ca", "b"])\
          and out_obj['content'] == []:
         del out_obj['content']
     if "eid" in out_obj and key in ['verse', 'chapter']:

--- a/tests/advanced/custom-attributes/origin.json
+++ b/tests/advanced/custom-attributes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/advanced/default-attributes/origin.json
+++ b/tests/advanced/default-attributes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/advanced/header/origin.json
+++ b/tests/advanced/header/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/advanced/list/origin.json
+++ b/tests/advanced/list/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/advanced/milestones/origin.json
+++ b/tests/advanced/milestones/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/advanced/nesting/origin.json
+++ b/tests/advanced/nesting/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/advanced/nesting1/origin.json
+++ b/tests/advanced/nesting1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/advanced/periph/origin.json
+++ b/tests/advanced/periph/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/basic/attributes/origin.json
+++ b/tests/basic/attributes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/basic/character/origin.json
+++ b/tests/basic/character/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/basic/cross-refs/origin.json
+++ b/tests/basic/cross-refs/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/basic/footnote/origin.json
+++ b/tests/basic/footnote/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/basic/header/origin.json
+++ b/tests/basic/header/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/basic/minimal/origin.json
+++ b/tests/basic/minimal/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/basic/multiple-chapters/origin.json
+++ b/tests/basic/multiple-chapters/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/basic/multiple-paragraphs/origin.json
+++ b/tests/basic/multiple-paragraphs/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/basic/section/origin.json
+++ b/tests/basic/section/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/biblica/BlankLinesWithFigures/origin.json
+++ b/tests/biblica/BlankLinesWithFigures/origin.json
@@ -17,7 +17,7 @@
       "sid": "EXO 25"
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b",
       "content": [
         {

--- a/tests/biblica/BlankLinesWithFigures/origin.json
+++ b/tests/biblica/BlankLinesWithFigures/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/biblica/PublishingVersesWithFormatting/origin.json
+++ b/tests/biblica/PublishingVersesWithFormatting/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/introductions/bad/test1/origin.json
+++ b/tests/introductions/bad/test1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/mandatory/emptyV/origin.json
+++ b/tests/mandatory/emptyV/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/mandatory/id/origin.json
+++ b/tests/mandatory/id/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "chapter",

--- a/tests/mandatory/minimum/origin.json
+++ b/tests/mandatory/minimum/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/mandatory/v/origin.json
+++ b/tests/mandatory/v/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/CharStyleClosedAndReopened/origin.json
+++ b/tests/paratextTests/CharStyleClosedAndReopened/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/CharStyleCrossesFootnote/origin.json
+++ b/tests/paratextTests/CharStyleCrossesFootnote/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/CharStyleCrossesVerseNumber/origin.json
+++ b/tests/paratextTests/CharStyleCrossesVerseNumber/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/CharStyleNotClosed/origin.json
+++ b/tests/paratextTests/CharStyleNotClosed/origin.json
@@ -75,7 +75,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     }
   ]

--- a/tests/paratextTests/CharStyleNotClosed/origin.json
+++ b/tests/paratextTests/CharStyleNotClosed/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/CrossReferencesInsideCharacterMarker/origin.json
+++ b/tests/paratextTests/CrossReferencesInsideCharacterMarker/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/CustomAttributesAreValid/origin.json
+++ b/tests/paratextTests/CustomAttributesAreValid/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/EmptyFigure/origin.json
+++ b/tests/paratextTests/EmptyFigure/origin.json
@@ -68,7 +68,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     }
   ]

--- a/tests/paratextTests/EmptyFigure/origin.json
+++ b/tests/paratextTests/EmptyFigure/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/EmptyMarkers/origin.json
+++ b/tests/paratextTests/EmptyMarkers/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/FigureAttributesAreValid/origin.json
+++ b/tests/paratextTests/FigureAttributesAreValid/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/FigureNotClosed/origin.json
+++ b/tests/paratextTests/FigureNotClosed/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/FootnoteConsistencyCheck/origin.json
+++ b/tests/paratextTests/FootnoteConsistencyCheck/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/FootnoteNotClosed/origin.json
+++ b/tests/paratextTests/FootnoteNotClosed/origin.json
@@ -76,7 +76,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     }
   ]

--- a/tests/paratextTests/FootnoteNotClosed/origin.json
+++ b/tests/paratextTests/FootnoteNotClosed/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/FootnoteWithWrongSpacingAroundCaller/origin.json
+++ b/tests/paratextTests/FootnoteWithWrongSpacingAroundCaller/origin.json
@@ -76,7 +76,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     }
   ]

--- a/tests/paratextTests/FootnoteWithWrongSpacingAroundCaller/origin.json
+++ b/tests/paratextTests/FootnoteWithWrongSpacingAroundCaller/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/GlossaryCitationFormContainingWordMedialPunctuation_Pass/origin.json
+++ b/tests/paratextTests/GlossaryCitationFormContainingWordMedialPunctuation_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/GlossaryCitationFormContainsComma_Pass/origin.json
+++ b/tests/paratextTests/GlossaryCitationFormContainsComma_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/GlossaryCitationFormContainsNonWordformingPunctuation/origin.json
+++ b/tests/paratextTests/GlossaryCitationFormContainsNonWordformingPunctuation/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/GlossaryCitationFormEndsInPunctuation/origin.json
+++ b/tests/paratextTests/GlossaryCitationFormEndsInPunctuation/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/GlossaryCitationFormEndsInSpace/origin.json
+++ b/tests/paratextTests/GlossaryCitationFormEndsInSpace/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/GlossaryCitationFormEndsWithParentheses_Pass/origin.json
+++ b/tests/paratextTests/GlossaryCitationFormEndsWithParentheses_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/GlossaryCitationFormMultipleWords_Pass/origin.json
+++ b/tests/paratextTests/GlossaryCitationFormMultipleWords_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/GlossaryCitationForm_Pass/origin.json
+++ b/tests/paratextTests/GlossaryCitationForm_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/GlossaryNoKeywordErrors/origin.json
+++ b/tests/paratextTests/GlossaryNoKeywordErrors/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/IdMarkerInMiddleOfBook/origin.json
+++ b/tests/paratextTests/IdMarkerInMiddleOfBook/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/IgnoreKeywordErrorsOutsideOfGlossary/origin.json
+++ b/tests/paratextTests/IgnoreKeywordErrorsOutsideOfGlossary/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/InvalidAttributeValuesReported/origin.json
+++ b/tests/paratextTests/InvalidAttributeValuesReported/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/InvalidAttributes/origin.json
+++ b/tests/paratextTests/InvalidAttributes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/InvalidFigureAttributesReported/origin.json
+++ b/tests/paratextTests/InvalidFigureAttributesReported/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/InvalidMarker/origin.json
+++ b/tests/paratextTests/InvalidMarker/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/InvalidMilestone_EndWithoutStart/origin.json
+++ b/tests/paratextTests/InvalidMilestone_EndWithoutStart/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/InvalidMilestone_IdsDontMatch/origin.json
+++ b/tests/paratextTests/InvalidMilestone_IdsDontMatch/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/InvalidMilestone_MissingEnd/origin.json
+++ b/tests/paratextTests/InvalidMilestone_MissingEnd/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/InvalidRubyMarkup/origin.json
+++ b/tests/paratextTests/InvalidRubyMarkup/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/InvalidUsfm20Usage/origin.json
+++ b/tests/paratextTests/InvalidUsfm20Usage/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/LinkAttributesAreValid/origin.json
+++ b/tests/paratextTests/LinkAttributesAreValid/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/MajorTitleRequired/origin.json
+++ b/tests/paratextTests/MajorTitleRequired/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/MarkersMissingSpace/origin.json
+++ b/tests/paratextTests/MarkersMissingSpace/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/MissingColumnInTable/origin.json
+++ b/tests/paratextTests/MissingColumnInTable/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/MissingIdAndChapterMarkers/origin.json
+++ b/tests/paratextTests/MissingIdAndChapterMarkers/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "para",

--- a/tests/paratextTests/MissingIdMarker/origin.json
+++ b/tests/paratextTests/MissingIdMarker/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "chapter",

--- a/tests/paratextTests/MissingRequiredAttributesReported/origin.json
+++ b/tests/paratextTests/MissingRequiredAttributesReported/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/NbMarkerInCorrectPlace/origin.json
+++ b/tests/paratextTests/NbMarkerInCorrectPlace/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/NestingInCrossReferences/origin.json
+++ b/tests/paratextTests/NestingInCrossReferences/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/NestingInFootnote/origin.json
+++ b/tests/paratextTests/NestingInFootnote/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/NestingUnclosed/origin.json
+++ b/tests/paratextTests/NestingUnclosed/origin.json
@@ -83,7 +83,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     }
   ]

--- a/tests/paratextTests/NestingUnclosed/origin.json
+++ b/tests/paratextTests/NestingUnclosed/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/NoErrorsEmptyBook/origin.json
+++ b/tests/paratextTests/NoErrorsEmptyBook/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/NoErrorsNesting/origin.json
+++ b/tests/paratextTests/NoErrorsNesting/origin.json
@@ -83,7 +83,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     }
   ]

--- a/tests/paratextTests/NoErrorsNesting/origin.json
+++ b/tests/paratextTests/NoErrorsNesting/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/NoErrorsPartiallyEmptyBook/origin.json
+++ b/tests/paratextTests/NoErrorsPartiallyEmptyBook/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/NoErrorsShort/origin.json
+++ b/tests/paratextTests/NoErrorsShort/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/NoErrosLong/origin.json
+++ b/tests/paratextTests/NoErrosLong/origin.json
@@ -76,7 +76,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     }
   ]

--- a/tests/paratextTests/NoErrosLong/origin.json
+++ b/tests/paratextTests/NoErrosLong/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/OnlyChapterAndVerseMarkers/origin.json
+++ b/tests/paratextTests/OnlyChapterAndVerseMarkers/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/UnmatchedSidebarEnd/origin.json
+++ b/tests/paratextTests/UnmatchedSidebarEnd/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/UnmatchedSidebarStart/origin.json
+++ b/tests/paratextTests/UnmatchedSidebarStart/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/ValidMilestones/origin.json
+++ b/tests/paratextTests/ValidMilestones/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/ValidRubyMarkup/origin.json
+++ b/tests/paratextTests/ValidRubyMarkup/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerKeywordContainsComma_Pass/origin.json
+++ b/tests/paratextTests/WordlistMarkerKeywordContainsComma_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerKeywordContainsNonWordformingPunctuation/origin.json
+++ b/tests/paratextTests/WordlistMarkerKeywordContainsNonWordformingPunctuation/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerKeywordEndsInPunctuation/origin.json
+++ b/tests/paratextTests/WordlistMarkerKeywordEndsInPunctuation/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerKeywordEndsInSpace/origin.json
+++ b/tests/paratextTests/WordlistMarkerKeywordEndsInSpace/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerKeywordEndsInSpaceGlossaryEntryPresent_Pass/origin.json
+++ b/tests/paratextTests/WordlistMarkerKeywordEndsInSpaceGlossaryEntryPresent_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerKeywordWithParentheses_Pass/origin.json
+++ b/tests/paratextTests/WordlistMarkerKeywordWithParentheses_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerMissingFromGlossaryCitationForms/origin.json
+++ b/tests/paratextTests/WordlistMarkerMissingFromGlossaryCitationForms/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerNestedProperNounWithKeyword_Pass/origin.json
+++ b/tests/paratextTests/WordlistMarkerNestedProperNounWithKeyword_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerNestedProperNoun_Pass/origin.json
+++ b/tests/paratextTests/WordlistMarkerNestedProperNoun_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerNestedShouldNotIncludeKeyword/origin.json
+++ b/tests/paratextTests/WordlistMarkerNestedShouldNotIncludeKeyword/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerNestedTwoProperNouns_Pass/origin.json
+++ b/tests/paratextTests/WordlistMarkerNestedTwoProperNouns_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerTextContainsNonWordformingPunctuation/origin.json
+++ b/tests/paratextTests/WordlistMarkerTextContainsNonWordformingPunctuation/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerTextEndsInPunctuation/origin.json
+++ b/tests/paratextTests/WordlistMarkerTextEndsInPunctuation/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerTextEndsInSpaceAndMissingFromGlossary/origin.json
+++ b/tests/paratextTests/WordlistMarkerTextEndsInSpaceAndMissingFromGlossary/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerTextEndsInSpaceGlossaryEntryPresent_Pass/origin.json
+++ b/tests/paratextTests/WordlistMarkerTextEndsInSpaceGlossaryEntryPresent_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerTextEndsInSpaceWithGlossary/origin.json
+++ b/tests/paratextTests/WordlistMarkerTextEndsInSpaceWithGlossary/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerTextEndsInSpaceWithoutGlossary/origin.json
+++ b/tests/paratextTests/WordlistMarkerTextEndsInSpaceWithoutGlossary/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerWithKeyword_Pass/origin.json
+++ b/tests/paratextTests/WordlistMarkerWithKeyword_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/WEB1/origin.json
+++ b/tests/samples-from-wild/WEB1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/WEB2/origin.json
+++ b/tests/samples-from-wild/WEB2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/WEB2/origin.json
+++ b/tests/samples-from-wild/WEB2/origin.json
@@ -172,7 +172,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -479,7 +479,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -1526,7 +1526,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -1810,7 +1810,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -2208,7 +2208,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -2419,7 +2419,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -2730,7 +2730,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -2894,7 +2894,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -3205,7 +3205,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -3322,7 +3322,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -3413,7 +3413,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -3497,7 +3497,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -4315,7 +4315,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -4646,7 +4646,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -4850,7 +4850,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -5068,7 +5068,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -5312,7 +5312,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -5436,7 +5436,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -11680,7 +11680,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -12290,7 +12290,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -12920,7 +12920,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -13250,7 +13250,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -13354,7 +13354,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -13398,7 +13398,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -13442,7 +13442,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -13486,7 +13486,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -13510,7 +13510,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -13541,7 +13541,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -13718,7 +13718,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -13742,7 +13742,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -13786,7 +13786,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -13871,7 +13871,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -14155,7 +14155,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -14348,7 +14348,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -14819,7 +14819,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -14836,7 +14836,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -15287,7 +15287,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -16613,7 +16613,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -16766,7 +16766,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -18110,7 +18110,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -18154,7 +18154,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -18232,7 +18232,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -18256,7 +18256,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -18347,7 +18347,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -18371,7 +18371,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -18444,7 +18444,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -18482,7 +18482,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -18540,7 +18540,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -18571,7 +18571,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -18635,7 +18635,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -18739,7 +18739,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -18810,7 +18810,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -18887,7 +18887,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -19065,7 +19065,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {

--- a/tests/samples-from-wild/WEB3/origin.json
+++ b/tests/samples-from-wild/WEB3/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/brenton1/origin.json
+++ b/tests/samples-from-wild/brenton1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/brenton2/origin.json
+++ b/tests/samples-from-wild/brenton2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/chinese1/origin.json
+++ b/tests/samples-from-wild/chinese1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/chinese2/origin.json
+++ b/tests/samples-from-wild/chinese2/origin.json
@@ -219,7 +219,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -864,7 +864,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {

--- a/tests/samples-from-wild/chinese2/origin.json
+++ b/tests/samples-from-wild/chinese2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/chinese3/origin.json
+++ b/tests/samples-from-wild/chinese3/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/doo43-1/origin.json
+++ b/tests/samples-from-wild/doo43-1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/doo43-3/origin.json
+++ b/tests/samples-from-wild/doo43-3/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/doo43-4/origin.json
+++ b/tests/samples-from-wild/doo43-4/origin.json
@@ -448,7 +448,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -499,7 +499,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -569,7 +569,7 @@
       "content": []
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -593,7 +593,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {

--- a/tests/samples-from-wild/doo43-4/origin.json
+++ b/tests/samples-from-wild/doo43-4/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/hindi-IRV1/origin.json
+++ b/tests/samples-from-wild/hindi-IRV1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/hindi-IRV2/origin.json
+++ b/tests/samples-from-wild/hindi-IRV2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/rv2/origin.json
+++ b/tests/samples-from-wild/rv2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/rv3/origin.json
+++ b/tests/samples-from-wild/rv3/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/t4t1/origin.json
+++ b/tests/samples-from-wild/t4t1/origin.json
@@ -11236,7 +11236,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -11345,7 +11345,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -11462,7 +11462,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -11674,7 +11674,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {

--- a/tests/samples-from-wild/t4t1/origin.json
+++ b/tests/samples-from-wild/t4t1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/t4t3/origin.json
+++ b/tests/samples-from-wild/t4t3/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/ta2il-IRV1/origin.json
+++ b/tests/samples-from-wild/ta2il-IRV1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/tamil-IRV1/origin.json
+++ b/tests/samples-from-wild/tamil-IRV1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/attributes/origin.json
+++ b/tests/specExamples/attributes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/chapter-verse/origin.json
+++ b/tests/specExamples/chapter-verse/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/character/origin.json
+++ b/tests/specExamples/character/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/cross-ref/origin.json
+++ b/tests/specExamples/cross-ref/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/extended/bookIntroductions1/origin.json
+++ b/tests/specExamples/extended/bookIntroductions1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/extended/bookIntroductions2/origin.json
+++ b/tests/specExamples/extended/bookIntroductions2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/extended/contentCatogories1/origin.json
+++ b/tests/specExamples/extended/contentCatogories1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/extended/contentCatogories1/origin.json
+++ b/tests/specExamples/extended/contentCatogories1/origin.json
@@ -164,17 +164,17 @@
               "type": "char",
               "marker": "ft",
               "content": [
-                "In 597"
+                "In 597",
+                {
+                  "type": "char",
+                  "marker": "sc",
+                  "content": [
+                    "BC"
+                  ]
+                },
+                "King Nebuchadnezzar \nof Babylonia conquered Jerusalem and took many of its inhabitants as prisoners to his \ncountry (2 Kgs 24.10-16; 2 Chr 36.9-10)."
               ]
-            },
-            {
-              "type": "char",
-              "marker": "sc",
-              "content": [
-                "BC"
-              ]
-            },
-            "King Nebuchadnezzar \nof Babylonia conquered Jerusalem and took many of its inhabitants as prisoners to his \ncountry (2 Kgs 24.10-16; 2 Chr 36.9-10)."
+            }
           ]
         },
         ", the following ancestors are listed: ..."

--- a/tests/specExamples/extended/contentCatogories2/origin.json
+++ b/tests/specExamples/extended/contentCatogories2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/extended/footnotes/origin.json
+++ b/tests/specExamples/extended/footnotes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/extended/sectionIntroductions/origin.json
+++ b/tests/specExamples/extended/sectionIntroductions/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/extended/sectionIntroductions/origin.json
+++ b/tests/specExamples/extended/sectionIntroductions/origin.json
@@ -1,0 +1,119 @@
+{
+  "type": "USJ",
+  "version": "0.2.0",
+  "content": [
+    {
+      "type": "book",
+      "marker": "id",
+      "code": "MRK",
+      "content": [
+        "- Good News Study Bible - Notes Material"
+      ]
+    },
+    {
+      "type": "chapter",
+      "marker": "c",
+      "number": "1",
+      "sid": "MRK 1"
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "12",
+          "sid": "MRK 1:12"
+        },
+        "At once the Spirit made him go into the desert,",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "13",
+          "sid": "MRK 1:13"
+        },
+        "where he stayed 40 days, being tempted by Satan. Wild animals were there also, but angels came and helped him."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ms",
+      "content": [
+        "Jesus' Public Ministry in Galilee"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "mr",
+      "content": [
+        "1.14--9.50"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ip",
+      "content": [
+        "Jesus returns to Galilee and does not go back to Judea until the close of his public ministry. There is no indication of how long his Galilean ministry lasted: only when he is back in Judea is a",
+        {
+          "type": "char",
+          "marker": "w",
+          "content": [
+            "festival"
+          ]
+        },
+        "(",
+        {
+          "type": "char",
+          "marker": "w",
+          "content": [
+            "passover"
+          ]
+        },
+        ") mentioned (14.1). He spends much of his time in Capernaum (1.21; 2.1; 3.1, 20; 9.33) and other places around Lake Galilee (1.9; 2.13; 3.7; 4.1). Twice Jesus ventures out of Galilee: into the region of the Ten Towns (5.1-20) and Phoenicia (7.24-31). His actions and teachings soon arouse opposition from the religious leaders (2.6-7, 24; 3.6, 22; 7.1-13; 8.11-12), and before long he predicts his coming arrest, condemnation, and crucifixion (8.31; 9.30-31)."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s1",
+      "content": [
+        "Jesus Calls Four Fishermen"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "r",
+      "content": [
+        "(Mt 4.12-22; Lk 4.14-15; 5.1-11)"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ip",
+      "content": [
+        "Jesus' message is about the arrival of the",
+        {
+          "type": "char",
+          "marker": "w",
+          "content": [
+            "kingdom of god"
+          ]
+        },
+        ", which will happen soon. To prepare for it, the people need to repent (1.15). He immediately summons two pairs of fishermen brothers to be his followers and helpers."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "14",
+          "sid": "MRK 1:14"
+        },
+        "After John had been put in prison, Jesus went to Galilee and preached the Good News from God."
+      ]
+    }
+  ]
+}

--- a/tests/specExamples/extended/sidebars/origin.json
+++ b/tests/specExamples/extended/sidebars/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/footnote/origin.json
+++ b/tests/specExamples/footnote/origin.json
@@ -174,7 +174,13 @@
                 "38"
               ]
             },
-            "As the scripture says, ‘Streams of life-giving water will pour out ...’”"
+            {
+              "type": "char",
+              "marker": "ft",
+              "content": [
+                "As the scripture says, ‘Streams of life-giving water will pour out ...’”"
+              ]
+            }
           ]
         },
         {

--- a/tests/specExamples/footnote/origin.json
+++ b/tests/specExamples/footnote/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/identification/origin.json
+++ b/tests/specExamples/identification/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/identification/origin.json
+++ b/tests/specExamples/identification/origin.json
@@ -1,0 +1,151 @@
+{
+  "type": "USJ",
+  "version": "0.2.0",
+  "content": [
+    {
+      "type": "book",
+      "marker": "id",
+      "code": "MAT",
+      "content": [
+        "41MATGNT92.SFM, Good News Translation, June 2003"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "usfm",
+      "content": [
+        "3.0"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ide",
+      "content": [
+        "UTF-8"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ide",
+      "content": [
+        "CP-1252"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ide",
+      "content": [
+        "Custom (TGUARANI.TTF)"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "sts",
+      "content": [
+        "2"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "h1",
+      "content": [
+        "Matthew"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "rem",
+      "content": [
+        "Assigned to <translator's name>."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "rem",
+      "content": [
+        "First draft complete, waiting for checks."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "toc1",
+      "content": [
+        "The Gospel According to Matthew"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "toc2",
+      "content": [
+        "Matthew"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "toc3",
+      "content": [
+        "Mat"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "toca1",
+      "content": [
+        "മത്തായി എഴുതിയ സുവിശേഷം"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "toca2",
+      "content": [
+        "മത്തായി"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "toca3",
+      "content": [
+        "മത്താ"
+      ]
+    },
+    {
+      "type": "chapter",
+      "marker": "c",
+      "number": "1",
+      "sid": "MAT 1"
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "1",
+          "sid": "MAT 1:1"
+        },
+        "ക്രിസ്തുയേശുവിന്റെ ബദ്ധനായ ...",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "2",
+          "sid": "MAT 1:2"
+        },
+        "നമ്മുടെ പിതാവായ ..."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "3",
+          "sid": "MAT 1:3"
+        },
+        "കർത്താവായ യേശുവിനോടും ..."
+      ]
+    }
+  ]
+}

--- a/tests/specExamples/introduction1/origin.json
+++ b/tests/specExamples/introduction1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/introduction2/origin.json
+++ b/tests/specExamples/introduction2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/introduction3/origin.json
+++ b/tests/specExamples/introduction3/origin.json
@@ -1,0 +1,148 @@
+{
+  "type": "USJ",
+  "version": "0.2.0",
+  "content": [
+    {
+      "type": "book",
+      "marker": "id",
+      "code": "MAT",
+      "content": [
+        "41MATGNT92.SFM, Good News Translation, June 2003"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ip",
+      "content": [
+        "However, he is more than a teacher, healer, or",
+        {
+          "type": "char",
+          "marker": "w",
+          "content": [
+            "miracle"
+          ]
+        },
+        "-worker. He is also ..."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ili",
+      "content": [
+        "1",
+        {
+          "type": "char",
+          "marker": "k",
+          "content": [
+            "The Messiah"
+          ]
+        },
+        "is the one promised by God, the one who would come and free God's people. By the time",
+        {
+          "type": "char",
+          "marker": "bk",
+          "content": [
+            "The Gospel of Mark"
+          ]
+        },
+        "appeared, the title \"Messiah\" (in Greek, \"",
+        {
+          "type": "char",
+          "marker": "w",
+          "content": [
+            "christ"
+          ]
+        },
+        "\") had become ..."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ili",
+      "content": [
+        "2",
+        {
+          "type": "char",
+          "marker": "k",
+          "content": [
+            "The Son of God"
+          ]
+        },
+        "is the title by which the heavenly voice addresses Jesus at his baptism (1.11) and his transfiguration ..."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ili",
+      "content": [
+        "3",
+        {
+          "type": "char",
+          "marker": "k",
+          "content": [
+            "The Son of Man"
+          ]
+        },
+        "is the title most..."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "imte",
+      "content": [
+        "End of the Introduction to the Gospel of Mark"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ie",
+      "content": []
+    },
+    {
+      "type": "chapter",
+      "marker": "c",
+      "number": "1",
+      "sid": "MAT 1"
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "1",
+          "sid": "MAT 1:1"
+        },
+        "ക്രിസ്തുയേശുവിന്റെ ബദ്ധനായ ...",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "2",
+          "sid": "MAT 1:2"
+        },
+        "നമ്മുടെ പിതാവായ ..."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "iex",
+      "content": [
+        "Written to the Romans from Corinthus, and sent by Phebe servant of the church at Cenchrea."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "3",
+          "sid": "MAT 1:3"
+        },
+        "കർത്താവായ യേശുവിനോടും ..."
+      ]
+    }
+  ]
+}

--- a/tests/specExamples/introduction3/origin.json
+++ b/tests/specExamples/introduction3/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/list/origin.json
+++ b/tests/specExamples/list/origin.json
@@ -112,7 +112,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -123,7 +123,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {

--- a/tests/specExamples/list/origin.json
+++ b/tests/specExamples/list/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/milestone/origin.json
+++ b/tests/specExamples/milestone/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/paragraph/origin.json
+++ b/tests/specExamples/paragraph/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/paragraph/origin.json
+++ b/tests/specExamples/paragraph/origin.json
@@ -120,7 +120,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {

--- a/tests/specExamples/poetry/origin.json
+++ b/tests/specExamples/poetry/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/poetry/origin.json
+++ b/tests/specExamples/poetry/origin.json
@@ -128,7 +128,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {
@@ -146,7 +146,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b",
       "content": [
         {
@@ -180,7 +180,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {

--- a/tests/specExamples/poetry/origin.json
+++ b/tests/specExamples/poetry/origin.json
@@ -1,0 +1,194 @@
+{
+  "type": "USJ",
+  "version": "0.2.0",
+  "content": [
+    {
+      "type": "book",
+      "marker": "id",
+      "code": "MAT",
+      "content": [
+        "41MATGNT92.SFM, Good News Translation, June 2003"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "usfm",
+      "content": [
+        "3.0"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "toc1",
+      "content": [
+        "The Acts of the Apostles"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "toc2",
+      "content": [
+        "Acts"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ip",
+      "content": [
+        "One of these brothers, Joseph, had become..."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ipr",
+      "content": [
+        "(50.24)"
+      ]
+    },
+    {
+      "type": "chapter",
+      "marker": "c",
+      "number": "136",
+      "sid": "MAT 136"
+    },
+    {
+      "type": "para",
+      "marker": "qa",
+      "content": [
+        "Aleph"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s1",
+      "content": [
+        "God's Love Never Fails"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "q1",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "1",
+          "sid": "MAT 136:1"
+        },
+        {
+          "type": "char",
+          "marker": "qac",
+          "content": [
+            "P"
+          ]
+        },
+        "Praise the",
+        {
+          "type": "char",
+          "marker": "nd",
+          "content": [
+            "Lord"
+          ]
+        },
+        "! He is good."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "qr",
+      "content": [
+        "God's love never fails",
+        {
+          "type": "char",
+          "marker": "qs",
+          "content": [
+            "Selah"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "q1",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "2",
+          "sid": "MAT 136:2"
+        },
+        "Praise the God of all gods."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "q1",
+      "content": [
+        "May his glory fill the whole world."
+      ]
+    },
+    {
+      "type": "optbreak",
+      "marker": "b"
+    },
+    {
+      "type": "para",
+      "marker": "qc",
+      "content": [
+        "Amen! Amen!"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "qd",
+      "content": [
+        "For the director of music. On my stringed instruments."
+      ]
+    },
+    {
+      "type": "optbreak",
+      "marker": "b",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "18",
+          "sid": "MAT 136:18"
+        },
+        "God's spirit took control of one of them, Amasai, who later became the commander of “The Thirty,” and he called out,"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "qm1",
+      "content": [
+        "“David son of Jesse, we are yours!"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "qm1",
+      "content": [
+        "Success to you and those who help you!"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "qm1",
+      "content": [
+        "God is on your side.”"
+      ]
+    },
+    {
+      "type": "optbreak",
+      "marker": "b"
+    },
+    {
+      "type": "para",
+      "marker": "m",
+      "content": [
+        "David welcomed them and made them officers in his army."
+      ]
+    }
+  ]
+}

--- a/tests/specExamples/table/origin.json
+++ b/tests/specExamples/table/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/titles/origin.json
+++ b/tests/specExamples/titles/origin.json
@@ -180,7 +180,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {

--- a/tests/specExamples/titles/origin.json
+++ b/tests/specExamples/titles/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/IRV1/origin.json
+++ b/tests/special-cases/IRV1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/IRV2/origin.json
+++ b/tests/special-cases/IRV2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/IRV3/origin.json
+++ b/tests/special-cases/IRV3/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/IRV4/origin.json
+++ b/tests/special-cases/IRV4/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/IRV5/origin.json
+++ b/tests/special-cases/IRV5/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/IRV6/origin.json
+++ b/tests/special-cases/IRV6/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/IRV7/origin.json
+++ b/tests/special-cases/IRV7/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/IRV8/origin.json
+++ b/tests/special-cases/IRV8/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/IRV9/origin.json
+++ b/tests/special-cases/IRV9/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-attributes/origin.json
+++ b/tests/special-cases/empty-attributes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-attributes/origin.json
+++ b/tests/special-cases/empty-attributes/origin.json
@@ -1,0 +1,96 @@
+{
+  "type": "USJ",
+  "version": "0.2.0",
+  "content": [
+    {
+      "type": "book",
+      "marker": "id",
+      "code": "GEN",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "mt1",
+      "content": [
+        "ഉല്പത്തിപുസ്തകം"
+      ]
+    },
+    {
+      "type": "chapter",
+      "marker": "c",
+      "number": "1",
+      "sid": "GEN 1"
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "1",
+          "sid": "GEN 1:1"
+        },
+        "ആദിയിൽ ദൈവം",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ആകാശം",
+          "strong": "l",
+          "x-morph": "He,R:Sp1cs",
+          "content": [
+            "ആകാശവും"
+          ]
+        },
+        "ഭൂമിയും സൃഷ്ടിച്ചു.",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "2",
+          "sid": "GEN 1:2"
+        },
+        "ആദിയിൽ ദൈവം",
+        {
+          "type": "char",
+          "marker": "w",
+          "content": [
+            "ആകാശവും |lemma=\"\" strong=\"l\" x-morph=\"He,R:Sp1cs\""
+          ]
+        },
+        "ഭൂമിയും സൃഷ്ടിച്ചു.",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "3",
+          "sid": "GEN 1:3"
+        },
+        "ആദിയിൽ ദൈവം",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "\"ആകാശം\"",
+          "content": [
+            "ആകാശവും"
+          ]
+        },
+        "ഭൂമിയും സൃഷ്ടിച്ചു.",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "4",
+          "sid": "GEN 1:4"
+        },
+        "ആദിയിൽ ദൈവം",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ആകാശം",
+          "content": [
+            "ആകാശവും"
+          ]
+        },
+        "ഭൂമിയും സൃഷ്ടിച്ചു."
+      ]
+    }
+  ]
+}

--- a/tests/special-cases/empty-attributes2/origin.json
+++ b/tests/special-cases/empty-attributes2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-attributes3/origin.json
+++ b/tests/special-cases/empty-attributes3/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-attributes4/origin.json
+++ b/tests/special-cases/empty-attributes4/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-attributes5/origin.json
+++ b/tests/special-cases/empty-attributes5/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-book/origin.json
+++ b/tests/special-cases/empty-book/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-c/origin.json
+++ b/tests/special-cases/empty-c/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-li/origin.json
+++ b/tests/special-cases/empty-li/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-lines/origin.json
+++ b/tests/special-cases/empty-lines/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-para/origin.json
+++ b/tests/special-cases/empty-para/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-para/origin.json
+++ b/tests/special-cases/empty-para/origin.json
@@ -20,7 +20,7 @@
       "content": []
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {

--- a/tests/special-cases/empty-para2/origin.json
+++ b/tests/special-cases/empty-para2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/figure_with_quotes_in_desc/origin.json
+++ b/tests/special-cases/figure_with_quotes_in_desc/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/id-in-text/origin.json
+++ b/tests/special-cases/id-in-text/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/nbsp/origin.json
+++ b/tests/special-cases/nbsp/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/nested-notes/origin.json
+++ b/tests/special-cases/nested-notes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/nesting/origin.json
+++ b/tests/special-cases/nesting/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/newline-attributes/origin.json
+++ b/tests/special-cases/newline-attributes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/notes/origin.json
+++ b/tests/special-cases/notes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/notes2/origin.json
+++ b/tests/special-cases/notes2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/pi/origin.json
+++ b/tests/special-cases/pi/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/punct-at-break/origin.json
+++ b/tests/special-cases/punct-at-break/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/qa/origin.json
+++ b/tests/special-cases/qa/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/sp/origin.json
+++ b/tests/special-cases/sp/origin.json
@@ -42,7 +42,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     }
   ]

--- a/tests/special-cases/sp/origin.json
+++ b/tests/special-cases/sp/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/1ch_verse_span/origin.json
+++ b/tests/usfmjsTests/1ch_verse_span/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/57-TIT.greek/origin.json
+++ b/tests/usfmjsTests/57-TIT.greek/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/57-TIT.partial/origin.json
+++ b/tests/usfmjsTests/57-TIT.partial/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/acts-1-20.aligned/origin.json
+++ b/tests/usfmjsTests/acts-1-20.aligned/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/acts_1_11.aligned/origin.json
+++ b/tests/usfmjsTests/acts_1_11.aligned/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/acts_1_11/origin.json
+++ b/tests/usfmjsTests/acts_1_11/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/acts_1_4.aligned/origin.json
+++ b/tests/usfmjsTests/acts_1_4.aligned/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/acts_1_4/origin.json
+++ b/tests/usfmjsTests/acts_1_4/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/acts_1_milestone/origin.json
+++ b/tests/usfmjsTests/acts_1_milestone/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/acts_8-37-ugnt-footnote/origin.json
+++ b/tests/usfmjsTests/acts_8-37-ugnt-footnote/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/chunk/origin.json
+++ b/tests/usfmjsTests/chunk/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/chunk_footnote/origin.json
+++ b/tests/usfmjsTests/chunk_footnote/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/esb/origin.json
+++ b/tests/usfmjsTests/esb/origin.json
@@ -1,0 +1,88 @@
+{
+  "type": "USJ",
+  "version": "0.2.0",
+  "content": [
+    {
+      "type": "book",
+      "marker": "id",
+      "code": "GEN",
+      "content": []
+    },
+    {
+      "type": "chapter",
+      "marker": "c",
+      "number": "1",
+      "sid": "GEN 1"
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "16",
+          "sid": "GEN 1:16"
+        }
+      ]
+    },
+    {
+      "type": "sidebar",
+      "marker": "esb",
+      "category": "History",
+      "content": [
+        {
+          "type": "para",
+          "marker": "ms",
+          "content": [
+            "Fish and Fishing"
+          ]
+        },
+        {
+          "type": "para",
+          "marker": "p",
+          "content": [
+            "In Jesus' time, fishing took place mostly on lake Galilee, because Jewish people could not use many of the harbors along the coast of the Mediterranean Sea, since these harbors were often controlled by unfriendly neighbors. The most common fish in the Lake of Galilee were carp and catfish. The Law of Moses allowed people to eat any fish with fins and scales, but since catfish lack scales (as do eels and sharks) they were not to be eaten (",
+            {
+              "type": "char",
+              "marker": "xt",
+              "content": [
+                "Lev 11.9-12"
+              ]
+            },
+            "). Fish were also probably brought from Tyre and Sidon, where they were dried and salted. ..."
+          ]
+        },
+        {
+          "type": "para",
+          "marker": "p",
+          "content": [
+            "Among early Christians, the fish was a favorite image for Jesus, because the Greek word for fish (",
+            {
+              "type": "char",
+              "marker": "tl",
+              "content": [
+                "ichthus"
+              ]
+            },
+            ") consists of the first letters of the Greek words that tell who Jesus is:",
+            {
+              "type": "figure",
+              "marker": "fig",
+              "content": [
+                "Christian Fish Image"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        "Passing alongside the Sea of Galilee, he saw Simon and Andrew the brother of Simon casting a net into the sea, for they were fishermen."
+      ]
+    }
+  ]
+}

--- a/tests/usfmjsTests/esb/origin.json
+++ b/tests/usfmjsTests/esb/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/f10_gen12-2_empty_word/origin.json
+++ b/tests/usfmjsTests/f10_gen12-2_empty_word/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/greek.oldformat/origin.json
+++ b/tests/usfmjsTests/greek.oldformat/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/greek/origin.json
+++ b/tests/usfmjsTests/greek/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/heb-12-27.grc/origin.json
+++ b/tests/usfmjsTests/heb-12-27.grc/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/heb1-1_multi_alignment/origin.json
+++ b/tests/usfmjsTests/heb1-1_multi_alignment/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/hebrew_words.oldformat/origin.json
+++ b/tests/usfmjsTests/hebrew_words.oldformat/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/hebrew_words/origin.json
+++ b/tests/usfmjsTests/hebrew_words/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/inline_God/origin.json
+++ b/tests/usfmjsTests/inline_God/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/inline_words/origin.json
+++ b/tests/usfmjsTests/inline_words/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/isa_footnote/origin.json
+++ b/tests/usfmjsTests/isa_footnote/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/isa_inline_quotes/origin.json
+++ b/tests/usfmjsTests/isa_inline_quotes/origin.json
@@ -93,7 +93,13 @@
                 "50,070 men"
               ]
             },
-            ", some later copies and modern versions have,",
+            {
+              "type": "char",
+              "marker": "ft",
+              "content": [
+                ", some later copies and modern versions have,"
+              ]
+            },
             {
               "type": "char",
               "marker": "fqa",
@@ -146,7 +152,13 @@
                 "Tiphsah"
               ]
             },
-            ", one ancient version and some modern versions read,",
+            {
+              "type": "char",
+              "marker": "ft",
+              "content": [
+                ", one ancient version and some modern versions read,"
+              ]
+            },
             {
               "type": "char",
               "marker": "fqa",

--- a/tests/usfmjsTests/isa_inline_quotes/origin.json
+++ b/tests/usfmjsTests/isa_inline_quotes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/isa_verse_span/origin.json
+++ b/tests/usfmjsTests/isa_verse_span/origin.json
@@ -65,6 +65,11 @@
     },
     {
       "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
       "marker": "q1",
       "content": []
     },
@@ -80,23 +85,10 @@
         {
           "type": "verse",
           "marker": "v",
-          "number": "15",
-          "sid": "ISA 5:15"
+          "number": "15-16",
+          "sid": "ISA 5:15-16"
         },
-        "Man is brought down, and the great man is humbled, and the eyes of the lofty are cast down."
-      ]
-    },
-    {
-      "type": "para",
-      "marker": "q1",
-      "content": [
-        {
-          "type": "verse",
-          "marker": "v",
-          "number": "16",
-          "sid": "ISA 5:16"
-        },
-        "Yahweh of hosts is exalted in his justice, and God the Holy One shows himself holy by his righteousness."
+        "Man is brought down, and the great man is humbled, and the eyes of the lofty are cast down. Yahweh of hosts is exalted in his justice, and God the Holy One shows himself holy by his righteousness."
       ]
     },
     {

--- a/tests/usfmjsTests/isa_verse_span/origin.json
+++ b/tests/usfmjsTests/isa_verse_span/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/jmp/origin.json
+++ b/tests/usfmjsTests/jmp/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/job_footnote/origin.json
+++ b/tests/usfmjsTests/job_footnote/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/links/origin.json
+++ b/tests/usfmjsTests/links/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/luk_quotes/origin.json
+++ b/tests/usfmjsTests/luk_quotes/origin.json
@@ -1,0 +1,170 @@
+{
+  "type": "USJ",
+  "version": "0.2.0",
+  "content": [
+    {
+      "type": "book",
+      "marker": "id",
+      "code": "LUK",
+      "content": [
+        "Unlocked Literal Bible"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ide",
+      "content": [
+        "UTF-8"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "h",
+      "content": [
+        "Luke"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "toc1",
+      "content": [
+        "The Gospel of Luke"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "toc2",
+      "content": [
+        "Luke"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "toc3",
+      "content": [
+        "Luk"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "mt",
+      "content": [
+        "Luke"
+      ]
+    },
+    {
+      "type": "chapter",
+      "marker": "c",
+      "number": "4",
+      "sid": "LUK 4"
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "q1",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "18",
+          "sid": "LUK 4:18"
+        },
+        "\"The Spirit of the Lord is upon me,"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "q1",
+      "content": [
+        "because he anointed me to tell good news to the poor."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "q1",
+      "content": [
+        "He has sent me to proclaim freedom to the captives,"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "q1",
+      "content": [
+        "and recovery of sight to the blind,"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "q1",
+      "content": [
+        "to set free those who are oppressed,"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "q1",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "19",
+          "sid": "LUK 4:19"
+        },
+        "to proclaim the year of the Lord's favor.\""
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "chapter",
+      "marker": "c",
+      "number": "20",
+      "sid": "LUK 20"
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "17",
+          "sid": "LUK 20:17"
+        },
+        "But Jesus looked at them, and said, \"What is the meaning of that which is written:"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "q",
+      "content": [
+        "'The stone that the builders rejected has become the cornerstone'?"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "m",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "18",
+          "sid": "LUK 20:18"
+        },
+        "Every one who falls on that stone will be broken to pieces. But on whomever it falls, it will crush.\""
+      ]
+    }
+  ]
+}

--- a/tests/usfmjsTests/luk_quotes/origin.json
+++ b/tests/usfmjsTests/luk_quotes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/mat-4-6.whitespace/origin.json
+++ b/tests/usfmjsTests/mat-4-6.whitespace/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/mat-4-6/origin.json
+++ b/tests/usfmjsTests/mat-4-6/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/misc_footnotes/origin.json
+++ b/tests/usfmjsTests/misc_footnotes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/misc_footnotes/origin.json
+++ b/tests/usfmjsTests/misc_footnotes/origin.json
@@ -43,7 +43,13 @@
                 "and in the ruins of the rich, lambs will graze"
               ]
             },
-            "."
+            {
+              "type": "char",
+              "marker": "ft",
+              "content": [
+                "."
+              ]
+            }
           ]
         },
         {

--- a/tests/usfmjsTests/missing_verses/origin.json
+++ b/tests/usfmjsTests/missing_verses/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/missing_verses/origin.json
+++ b/tests/usfmjsTests/missing_verses/origin.json
@@ -77,7 +77,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {

--- a/tests/usfmjsTests/missing_verses/origin.json
+++ b/tests/usfmjsTests/missing_verses/origin.json
@@ -1,0 +1,158 @@
+{
+  "type": "USJ",
+  "version": "0.2.0",
+  "content": [
+    {
+      "type": "book",
+      "marker": "id",
+      "code": "PHP",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "ide",
+      "content": [
+        "UTF-8"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "h",
+      "content": [
+        "Philippians"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "toc1",
+      "content": [
+        "The Epistle of Paul the Apostle to the Philippians"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "toc2",
+      "content": [
+        "Philippians"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "toc3",
+      "content": [
+        "Php"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "mt",
+      "content": [
+        "The Epistle of Paul the Apostle to the Philippians"
+      ]
+    },
+    {
+      "type": "chapter",
+      "marker": "c",
+      "number": "1",
+      "sid": "PHP 1"
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "1",
+          "sid": "PHP 1:1"
+        },
+        "Paul and Timothy, servants of Christ Jesus, to all the ones set apart in Christ Jesus who are at Philippi, with the overseers and deacons.",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "2",
+          "sid": "PHP 1:2"
+        },
+        "Grace to you and peace from God our Father and the Lord Jesus Christ."
+      ]
+    },
+    {
+      "type": "optbreak",
+      "marker": "b"
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "5",
+          "sid": "PHP 1:5"
+        },
+        "I give thanks for your fellowship in the gospel from the first day until now.",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "6",
+          "sid": "PHP 1:6"
+        },
+        "I am confident of this very thing, that he who began a good work in you will complete it until the day of Jesus Christ."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "chapter",
+      "marker": "c",
+      "number": "2",
+      "sid": "PHP 2"
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "1",
+          "sid": "PHP 2:1"
+        },
+        "If there is therefore any encouragement in Christ, if any comfort from his love, if any fellowship of the Spirit, if any tender mercies and compassions,"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "3",
+          "sid": "PHP 2:3"
+        },
+        "Do nothing through selfishness or empty pride, but instead in lowliness of mind count others better than yourself.",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "4",
+          "sid": "PHP 2:4"
+        },
+        "Do not look out for each of your own needs, but also look out for the needs of others."
+      ]
+    }
+  ]
+}

--- a/tests/usfmjsTests/out_of_sequence_chapters/origin.json
+++ b/tests/usfmjsTests/out_of_sequence_chapters/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/out_of_sequence_verses/origin.json
+++ b/tests/usfmjsTests/out_of_sequence_verses/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/out_of_sequence_verses/origin.json
+++ b/tests/usfmjsTests/out_of_sequence_verses/origin.json
@@ -77,7 +77,7 @@
       ]
     },
     {
-      "type": "optbreak",
+      "type": "para",
       "marker": "b"
     },
     {

--- a/tests/usfmjsTests/out_of_sequence_verses/origin.json
+++ b/tests/usfmjsTests/out_of_sequence_verses/origin.json
@@ -1,0 +1,165 @@
+{
+  "type": "USJ",
+  "version": "0.2.0",
+  "content": [
+    {
+      "type": "book",
+      "marker": "id",
+      "code": "PHP",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "ide",
+      "content": [
+        "UTF-8"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "h",
+      "content": [
+        "Philippians"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "toc1",
+      "content": [
+        "The Epistle of Paul the Apostle to the Philippians"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "toc2",
+      "content": [
+        "Philippians"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "toc3",
+      "content": [
+        "Php"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "mt",
+      "content": [
+        "The Epistle of Paul the Apostle to the Philippians"
+      ]
+    },
+    {
+      "type": "chapter",
+      "marker": "c",
+      "number": "1",
+      "sid": "PHP 1"
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "2",
+          "sid": "PHP 1:2"
+        },
+        "Grace to you and peace from God our Father and the Lord Jesus Christ.",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "1",
+          "sid": "PHP 1:1"
+        },
+        "Paul and Timothy, servants of Christ Jesus, to all the ones set apart in Christ Jesus who are at Philippi, with the overseers and deacons."
+      ]
+    },
+    {
+      "type": "optbreak",
+      "marker": "b"
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "3",
+          "sid": "PHP 1:3"
+        },
+        "I thank my God with every thought of you,",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "5",
+          "sid": "PHP 1:5"
+        },
+        "I give thanks for your fellowship in the gospel from the first day until now.",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "4",
+          "sid": "PHP 1:4"
+        },
+        "Every time I pray for you, it is always a prayer of joy."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "chapter",
+      "marker": "c",
+      "number": "2",
+      "sid": "PHP 2"
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "1",
+          "sid": "PHP 2:1"
+        },
+        "If there is therefore any encouragement in Christ, if any comfort from his love, if any fellowship of the Spirit, if any tender mercies and compassions,"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "3",
+          "sid": "PHP 2:3"
+        },
+        "Do nothing through selfishness or empty pride, but instead in lowliness of mind count others better than yourself.",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "2",
+          "sid": "PHP 2:2"
+        },
+        "make my joy full so that you are of the same mind, have the same love, are united in spirit, and have the same purpose."
+      ]
+    }
+  ]
+}

--- a/tests/usfmjsTests/pro_footnote/origin.json
+++ b/tests/usfmjsTests/pro_footnote/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/pro_quotes/origin.json
+++ b/tests/usfmjsTests/pro_quotes/origin.json
@@ -138,7 +138,13 @@
                 "faithful one"
               ]
             },
-            "instead of",
+            {
+              "type": "char",
+              "marker": "ft",
+              "content": [
+                "instead of"
+              ]
+            },
             {
               "type": "char",
               "marker": "fqa",
@@ -182,7 +188,13 @@
                 "I will place help upon a warrior"
               ]
             },
-            ". Some translate the word for",
+            {
+              "type": "char",
+              "marker": "ft",
+              "content": [
+                ". Some translate the word for"
+              ]
+            },
             {
               "type": "char",
               "marker": "fqa",
@@ -190,12 +202,25 @@
                 "help"
               ]
             },
-            "as",
+            {
+              "type": "char",
+              "marker": "ft",
+              "content": [
+                "as"
+              ]
+            },
             {
               "type": "char",
               "marker": "fqa",
               "content": [
-                "crown, which is followed by the ULB here."
+                "crown"
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "ft",
+              "content": [
+                ", which is followed by the ULB here."
               ]
             }
           ]

--- a/tests/usfmjsTests/pro_quotes/origin.json
+++ b/tests/usfmjsTests/pro_quotes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/psa_quotes/origin.json
+++ b/tests/usfmjsTests/psa_quotes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/qt/origin.json
+++ b/tests/usfmjsTests/qt/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tit1-1_alignment/origin.json
+++ b/tests/usfmjsTests/tit1-1_alignment/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tit1-1_alignment_strongs/origin.json
+++ b/tests/usfmjsTests/tit1-1_alignment_strongs/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tit_1_12.alignment/origin.json
+++ b/tests/usfmjsTests/tit_1_12.alignment/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tit_1_12.no.words/origin.json
+++ b/tests/usfmjsTests/tit_1_12.no.words/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tit_1_12.oldformat/origin.json
+++ b/tests/usfmjsTests/tit_1_12.oldformat/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tit_1_12.word.not.at.line.start/origin.json
+++ b/tests/usfmjsTests/tit_1_12.word.not.at.line.start/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tit_1_12/origin.json
+++ b/tests/usfmjsTests/tit_1_12/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tit_1_12_footnote/origin.json
+++ b/tests/usfmjsTests/tit_1_12_footnote/origin.json
@@ -88,7 +88,13 @@
                 "in Ephesus,"
               ]
             },
-            "but this expression is probably in Paul's original letter."
+            {
+              "type": "char",
+              "marker": "ft",
+              "content": [
+                "but this expression is probably in Paul's original letter."
+              ]
+            }
           ]
         }
       ]

--- a/tests/usfmjsTests/tit_1_12_footnote/origin.json
+++ b/tests/usfmjsTests/tit_1_12_footnote/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tit_1_12_new_line/origin.json
+++ b/tests/usfmjsTests/tit_1_12_new_line/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tit_extra_space_after_chapter/origin.json
+++ b/tests/usfmjsTests/tit_extra_space_after_chapter/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tit_extra_space_after_chapter/origin.json
+++ b/tests/usfmjsTests/tit_extra_space_after_chapter/origin.json
@@ -1,0 +1,200 @@
+{
+  "type": "USJ",
+  "version": "0.2.0",
+  "content": [
+    {
+      "type": "book",
+      "marker": "id",
+      "code": "TIT",
+      "content": [
+        "Unlocked Literal Bible"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ide",
+      "content": [
+        "UTF-8"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "h",
+      "content": [
+        "Titus"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "toc1",
+      "content": [
+        "The Letter of Paul to Titus"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "toc2",
+      "content": [
+        "Titus"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "toc3",
+      "content": [
+        "Tit"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "mt",
+      "content": [
+        "Titus"
+      ]
+    },
+    {
+      "type": "chapter",
+      "marker": "c",
+      "number": "1",
+      "sid": "TIT 1"
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "1",
+          "sid": "TIT 1:1"
+        },
+        "Paul, a servant of God and an apostle of Jesus Christ, for the faith of God's chosen people and the knowledge of the truth that agrees with godliness,",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "2",
+          "sid": "TIT 1:2"
+        },
+        "with the certain hope of everlasting life that God, who does not lie, promised before all the ages of time.",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "3",
+          "sid": "TIT 1:3"
+        },
+        "At the right time, he revealed his word by the message that he trusted me to deliver, by the command of God our savior."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "4",
+          "sid": "TIT 1:4"
+        },
+        "To Titus, a true son in our common faith. Grace and peace from God the Father and Christ Jesus our savior."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "5",
+          "sid": "TIT 1:5"
+        },
+        "For this purpose I left you in Crete, that you might set in order things not yet complete and ordain elders in every city as I directed you."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "6",
+          "sid": "TIT 1:6"
+        },
+        "An elder must be without blame, the husband of one wife, with faithful children not accused of reckless behavior or undisciplined.",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "7",
+          "sid": "TIT 1:7"
+        },
+        "It is necessary for the overseer, as God's household manager, to be blameless. He must not be arrogant, not be easily angered, not addicted to wine, not a brawler, and not a greedy man."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "8",
+          "sid": "TIT 1:8"
+        },
+        "Instead, he should be hospitable and a friend of what is good. He must be sensible, righteous, godly, and self-controlled.",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "9",
+          "sid": "TIT 1:9"
+        },
+        "He should hold tightly to the trustworthy message that was taught, so that he may be able to encourage others with good teaching and correct those who oppose him."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "10",
+          "sid": "TIT 1:10"
+        },
+        "For there are many rebellious people, empty talkers and deceivers, especially those of the circumcision.",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "11",
+          "sid": "TIT 1:11"
+        },
+        "It is necessary to stop them. They are upsetting whole families by teaching for shameful profit what they should not teach."
+      ]
+    }
+  ]
+}

--- a/tests/usfmjsTests/ts_2/origin.json
+++ b/tests/usfmjsTests/ts_2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tstudio/origin.json
+++ b/tests/usfmjsTests/tstudio/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tw_words/origin.json
+++ b/tests/usfmjsTests/tw_words/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tw_words_chunk/origin.json
+++ b/tests/usfmjsTests/tw_words_chunk/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/usfmIntroTest/origin.json
+++ b/tests/usfmjsTests/usfmIntroTest/origin.json
@@ -1,0 +1,950 @@
+{
+  "type": "USJ",
+  "version": "0.2.0",
+  "content": [
+    {
+      "type": "book",
+      "marker": "id",
+      "code": "TIT",
+      "content": [
+        "Unlocked Literal Bible"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ide",
+      "content": [
+        "UTF-8"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "h",
+      "content": [
+        "Titus"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "toc1",
+      "content": [
+        "The Letter of Paul to Titus"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "toc2",
+      "content": [
+        "Titus"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "toc3",
+      "content": [
+        "Tit"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "mt",
+      "content": [
+        "Titus"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "iot",
+      "content": [
+        "Outline of Contents"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "io1",
+      "content": [
+        "The beginning of the gospel 1.1-13"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "io1",
+      "content": [
+        "Jesus' public ministry in Galilee 1.14-9.50"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "io1",
+      "content": [
+        "From Galilee to Jerusalem 10.1-52"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "io1",
+      "content": [
+        "The last week in and near Jerusalem 11.1-15.47"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "io1",
+      "content": [
+        "The resurrection of Jesus 16.1-8"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "io1",
+      "content": [
+        "[An Old Ending to the Gospel 16.9-20]"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "io1",
+      "content": [
+        "[Another Old Ending 16.9-10]"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ip",
+      "content": [
+        "The opening words of",
+        {
+          "type": "char",
+          "marker": "bk",
+          "content": [
+            "The Gospel according to Mark"
+          ]
+        },
+        "tell its readers that the subject of this book is the Good News about Jesus Christ. With the coming of Jesus Christ, it announces, the time set by God to bring salvation to humankind has arrived (1.15). Though the book concentrates on his deeds and words, it is not a biography of Jesus of Nazareth. Only one year, or a little more, of Jesus' life appears to be recorded (chapters 1--10), and over one-third of the book (chapters 11--16) is taken up with the last week of Jesus in and near",
+        {
+          "type": "char",
+          "marker": "w",
+          "content": [
+            "Jerusalem"
+          ]
+        },
+        ". Nothing is said about his birth, childhood, home, or parents. When he first appears, unknown and unannounced, Jesus is a full-grown adult who comes to John the Baptist to be",
+        {
+          "type": "char",
+          "marker": "w",
+          "content": [
+            "baptized"
+          ]
+        },
+        "by him."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ip",
+      "content": [
+        "The author's primary interest in writing is religious. The Gospel is written \"from",
+        {
+          "type": "char",
+          "marker": "w",
+          "content": [
+            "faith"
+          ]
+        },
+        "to faith\"."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "is1",
+      "content": [
+        "The Story"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ip",
+      "content": [
+        {
+          "type": "char",
+          "marker": "bk",
+          "content": [
+            "Mark's"
+          ]
+        },
+        "story of Jesus is told quickly and with an abundance of details that enhance its dramatic impact. Jesus appears suddenly in Judea, where he joins those who are being baptized in the Jordan by John the Baptist. Just as suddenly, he returns to Galilee, where he proclaims the message that the",
+        {
+          "type": "char",
+          "marker": "w",
+          "content": [
+            "kingdom of god"
+          ]
+        },
+        "is about to arrive."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ip",
+      "content": [
+        "However, he is more than a teacher, healer, or",
+        {
+          "type": "char",
+          "marker": "w",
+          "content": [
+            "miracle"
+          ]
+        },
+        "-worker. He is also the Messiah, the Son of God, the Son of Man. These three titles express the first Christians' understanding of who Jesus is."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ili",
+      "content": [
+        "1",
+        {
+          "type": "char",
+          "marker": "k",
+          "content": [
+            "The Messiah"
+          ]
+        },
+        "is the one promised by God, the one who would come and free God's people. By the time",
+        {
+          "type": "char",
+          "marker": "bk",
+          "content": [
+            "The Gospel of Mark"
+          ]
+        },
+        "appeared, the title \"Messiah\" (in Greek, \"",
+        {
+          "type": "char",
+          "marker": "w",
+          "content": [
+            "christ"
+          ]
+        },
+        "\") had become a proper name, so that the Gospel opens with \"the Good News about Jesus Christ\" (and not \"Jesus the Christ\"). Peter's confession (8.29) marks a turning-point in the ministry of Jesus. The title \"",
+        {
+          "type": "char",
+          "marker": "w",
+          "content": [
+            "son of david"
+          ]
+        },
+        "\" (10.46-48) also identifies Jesus as the Messiah, who would restore to Israel the power and glory it enjoyed under David's reign (also 12.35-37)."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ili",
+      "content": [
+        "2",
+        {
+          "type": "char",
+          "marker": "k",
+          "content": [
+            "The Son of God"
+          ]
+        },
+        "is the title by which the heavenly voice addresses Jesus at his baptism (1.11) and his transfiguration (9.7). And at Jesus' death the Roman officer confesses that Jesus is the Son of God (15.39)."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ili",
+      "content": [
+        "3",
+        {
+          "type": "char",
+          "marker": "k",
+          "content": [
+            "The Son of Man"
+          ]
+        },
+        "is the title most often used of Jesus, and it appears only on the lips of Jesus. This enigmatic title appears in",
+        {
+          "type": "char",
+          "marker": "bk",
+          "content": [
+            "The Book of Daniel"
+          ]
+        },
+        "(Dan 7.13n), where it is applied to the exalted figure to whom God gives universal dominion. In",
+        {
+          "type": "char",
+          "marker": "bk",
+          "content": [
+            "Mark"
+          ]
+        },
+        "the title is used of Jesus in three ways: the Son of Man acts with divine power (2.10, 28); he will be rejected, will suffer and die (8.31; 9.9, 12, 31; 10.33-34, 45; 14.21, 41); he will return in power and glory (8.38; 13.26; 14.62)."
+      ]
+    },
+    {
+      "type": "chapter",
+      "marker": "c",
+      "number": "1",
+      "sid": "TIT 1"
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "1",
+          "sid": "TIT 1:1"
+        },
+        "Paul, a servant of God and an apostle of Jesus Christ, for the faith of God's chosen people and the knowledge of the truth that agrees with godliness,",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "2",
+          "sid": "TIT 1:2"
+        },
+        "with the certain hope of everlasting life that God, who does not lie, promised before all the ages of time.",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "3",
+          "sid": "TIT 1:3"
+        },
+        "At the right time, he revealed his word by the message that he trusted me to deliver, by the command of God our savior."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "4",
+          "sid": "TIT 1:4"
+        },
+        "To Titus, a true son in our common faith. Grace and peace from God the Father and Christ Jesus our savior."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "5",
+          "sid": "TIT 1:5"
+        },
+        "For this purpose I left you in Crete, that you might set in order things not yet complete and ordain elders in every city as I directed you."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "6",
+          "sid": "TIT 1:6"
+        },
+        "An elder must be without blame, the husband of one wife, with faithful children not accused of reckless behavior or undisciplined.",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "7",
+          "sid": "TIT 1:7"
+        },
+        "It is necessary for the overseer, as God's household manager, to be blameless. He must not be arrogant, not be easily angered, not addicted to wine, not a brawler, and not a greedy man."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "8",
+          "sid": "TIT 1:8"
+        },
+        "Instead, he should be hospitable and a friend of what is good. He must be sensible, righteous, godly, and self-controlled.",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "9",
+          "sid": "TIT 1:9"
+        },
+        "He should hold tightly to the trustworthy message that was taught, so that he may be able to encourage others with good teaching and correct those who oppose him."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "10",
+          "sid": "TIT 1:10"
+        },
+        "For there are many rebellious people, empty talkers and deceivers, especially those of the circumcision.",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "11",
+          "sid": "TIT 1:11"
+        },
+        "It is necessary to stop them. They are upsetting whole families by teaching for shameful profit what they should not teach."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "12",
+          "sid": "TIT 1:12"
+        },
+        "At once the Spirit made him go into the desert,",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "13",
+          "sid": "TIT 1:13"
+        },
+        "where he stayed 40 days, being tempted by Satan. Wild animals were there also, but angels came and helped him."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ms",
+      "content": [
+        "Jesus' Public Ministry in Galilee"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "mr",
+      "content": [
+        "1.14--9.50"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ip",
+      "content": [
+        "Jesus returns to Galilee and does not go back to Judea until the close of his public ministry. There is no indication of how long his Galilean ministry lasted: only when he is back in Judea is a",
+        {
+          "type": "char",
+          "marker": "w",
+          "content": [
+            "festival"
+          ]
+        },
+        "mentioned (14.1). He spends much of his time in Capernaum (1.21; 2.1; 3.1, 20; 9.33) and other places around Lake Galilee (1.9; 2.13; 3.7; 4.1). Twice Jesus ventures out of Galilee: into the region of the Ten Towns (5.1-20) and Phoenicia (7.24-31). His actions and teachings soon arouse opposition from the religious leaders (2.6-7, 24; 3.6, 22; 7.1-13; 8.11-12), and before long he predicts his coming arrest, condemnation, and crucifixion (8.31; 9.30-31)."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s1",
+      "content": [
+        "Jesus Calls Four Fishermen"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "r",
+      "content": [
+        "(Mt 4.12-22; Lk 4.14-15; 5.1-11)"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ip",
+      "content": [
+        "Jesus' message is about the arrival of the",
+        {
+          "type": "char",
+          "marker": "w",
+          "content": [
+            "kingdom of god"
+          ]
+        },
+        ", which will happen soon. To prepare for it, the people need to repent (1.15). He immediately summons two pairs of fishermen brothers to be his followers and helpers."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "14",
+          "sid": "TIT 1:14"
+        },
+        "After John had been put in prison, Jesus went to Galilee and preached the Good News from God."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "15",
+          "sid": "TIT 1:15"
+        },
+        "To those who are pure, all things are pure. But to those who are corrupt and unbelieving, nothing is pure, but both their minds and their consciences have been corrupted.",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "16",
+          "sid": "TIT 1:16"
+        },
+        "They profess to know God, but they deny him by their actions. They are detestable, disobedient, and unfit for doing any good work."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "chapter",
+      "marker": "c",
+      "number": "2",
+      "sid": "TIT 2"
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "1",
+          "sid": "TIT 2:1"
+        },
+        "But you, speak what fits with faithful instruction.",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "2",
+          "sid": "TIT 2:2"
+        },
+        "Teach older men to be temperate, dignified, sensible, sound in faith, in love, and in perseverance."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "3",
+          "sid": "TIT 2:3"
+        },
+        "Teach older women likewise to be reverent in behavior, not slanderers or being slaves to much wine, but to be teachers of what is good.",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "4",
+          "sid": "TIT 2:4"
+        },
+        "In this way they may train the younger women to love their own husbands and children,",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "5",
+          "sid": "TIT 2:5"
+        },
+        "to be sensible, pure, good housekeepers, and obedient to their own husbands, so that God's word may not be insulted."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "6",
+          "sid": "TIT 2:6"
+        },
+        "In the same way, encourage the younger men to use good sense.",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "7",
+          "sid": "TIT 2:7"
+        },
+        "In all ways present yourself as an example of good works. In your teaching, show integrity, dignity,",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "8",
+          "sid": "TIT 2:8"
+        },
+        "and a correct message that is above criticism, so that anyone who opposes you may be ashamed because they have nothing bad to say about us."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "9",
+          "sid": "TIT 2:9"
+        },
+        "Teach slaves to obey their masters in everything, to please them and not argue with them,",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "10",
+          "sid": "TIT 2:10"
+        },
+        "to not steal from them, but instead to demonstrate all good faith, so that in every way they may bring credit to the teaching about God our Savior."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "11",
+          "sid": "TIT 2:11"
+        },
+        "For the grace of God has appeared for the salvation of all people.",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "12",
+          "sid": "TIT 2:12"
+        },
+        "It trains us to reject godlessness and worldly passions, and to live self-controlled, upright, and godly lives in this age,",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "13",
+          "sid": "TIT 2:13"
+        },
+        "while we look forward to receiving our blessed hope, the appearance of the glory of our great God and Savior Jesus Christ."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "14",
+          "sid": "TIT 2:14"
+        },
+        "Jesus gave himself for us in order to redeem us from all lawlessness and to make pure, for himself, a special people who are eager to do good works."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "15",
+          "sid": "TIT 2:15"
+        },
+        "Speak of these things, encourage people to do them, and give correction with all authority. Let no one disregard you."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "chapter",
+      "marker": "c",
+      "number": "3",
+      "sid": "TIT 3"
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "1",
+          "sid": "TIT 3:1"
+        },
+        "Remind them to submit to rulers and authorities, to obey them, to be ready for every good work,",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "2",
+          "sid": "TIT 3:2"
+        },
+        "to revile no one, to not be eager to fight, and to be gentle, showing all humility toward everyone."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "3",
+          "sid": "TIT 3:3"
+        },
+        "For once we ourselves were thoughtless and disobedient. We were led astray and enslaved by various passions and pleasures. We lived in evil and envy. We were detestable and hated one another."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "4",
+          "sid": "TIT 3:4"
+        },
+        "But when the kindness of God our savior and his love for mankind appeared,",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "5",
+          "sid": "TIT 3:5"
+        },
+        "it was not by works of righteousness that we did, but by his mercy that he saved us, through the washing of new birth and renewal by the Holy Spirit,"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "6",
+          "sid": "TIT 3:6"
+        },
+        "whom God richly poured on us through our Savior Jesus Christ,",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "7",
+          "sid": "TIT 3:7"
+        },
+        "so that having been justified by his grace, we might become heirs with the certain hope of eternal life."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "8",
+          "sid": "TIT 3:8"
+        },
+        "This message is trustworthy. I want you to insist on these things, so that those who have believed in God may be careful to engage themselves in good works. These things are good and useful for everyone."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "9",
+          "sid": "TIT 3:9"
+        },
+        "But avoid foolish debates and genealogies and strife and conflict about the law. Those things are unprofitable and worthless.",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "10",
+          "sid": "TIT 3:10"
+        },
+        "Reject anyone who is causing divisions among you, after one or two warnings,",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "11",
+          "sid": "TIT 3:11"
+        },
+        "knowing that such a person has turned from the right way and is sinning and condemns himself."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "12",
+          "sid": "TIT 3:12"
+        },
+        "When I send Artemas or Tychicus to you, hurry and come to me at Nicopolis, where I have decided to spend the winter.",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "13",
+          "sid": "TIT 3:13"
+        },
+        "Do everything you can to send on their way Zenas the lawyer and Apollos, so that they lack nothing."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "14",
+          "sid": "TIT 3:14"
+        },
+        "Our people must learn to engage themselves in good works that provide for urgent needs, and so not be unfruitful."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "15",
+          "sid": "TIT 3:15"
+        },
+        "All those who are with me greet you. Greet those who love us in faith. Grace be with all of you."
+      ]
+    }
+  ]
+}

--- a/tests/usfmjsTests/usfmIntroTest/origin.json
+++ b/tests/usfmjsTests/usfmIntroTest/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/valid/origin.json
+++ b/tests/usfmjsTests/valid/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "content": [
     {
       "type": "book",


### PR DESCRIPTION
This PR includes
1. Rerun USJ generation with latest USX samples in testsuite, being able to include 12 more USJ samples and make corresponding changes in some others.
2. `\b` represented as `{ type:"para", style:"b"}`
  1. Code changes for 2 in `scripts/usx2usj.py` and `lib/usfmtc/usjproc.py`
  2. Changes in testsuite samples as per 2
  3. USJ version bumped to `0.2.1` from `0.2.0` with the fix
  

##### Stats for USJ samples in test suite now

USFM samples: 256
USX samples: 253
USJ samples generated only for: **224**
(Converted only where USX was present and did not have elements with status='invalid' or other issues in it.)

 