### PR TITLE
Fix USJ schema and the way altnumber and pub number are handled

### DIFF
--- a/grammar/usj.js
+++ b/grammar/usj.js
@@ -1,5 +1,5 @@
 {
-  "$schema": "USJ-0.0.1",
+  "$schema": "USJ-0.2.3",
   "$id": "https://usfm-committee/usj.schema.json",
   "title": "Unified Scripture JSON",
   "description": "The JSON varient of USFM and USX data models",
@@ -59,7 +59,7 @@
           "type": "string"
         }
       },
-      "required": ["type"]
+      "required": ["type", "marker"]
     }
    },
   "properties": {

--- a/grammar/usj.js
+++ b/grammar/usj.js
@@ -1,5 +1,5 @@
 {
-  "$schema": "USJ-0.2.3",
+  "$schema": "USJ-0.2.4",
   "$id": "https://usfm-committee/usj.schema.json",
   "title": "Unified Scripture JSON",
   "description": "The JSON varient of USFM and USX data models",

--- a/python/lib/usfmtc/usjproc.py
+++ b/python/lib/usfmtc/usjproc.py
@@ -11,6 +11,7 @@ def usxtousj(input_usx_elmt):
     out_obj = {}
     action = "append"
     attribs = dict(input_usx_elmt.attrib)
+    alt_pub_numbers = []
     tag = None
     if "style" in attribs:
         tag = attribs['style']
@@ -21,6 +22,12 @@ def usxtousj(input_usx_elmt):
         del attribs['closed']
     if "status" in attribs:
         del attribs['status']
+    if "altnumber" in attribs:
+        alt_pub_numbers.append({'type':'char', "marker": f"{tag}a", "content":[attribs['altnumber']]})
+        del attribs['altnumber']
+    if "pubnumber" in attribs:
+        alt_pub_numbers.append({'type':'para', "marker": f"{tag}p", "content":[attribs['pubnumber']]})
+        del attribs['pubnumber']
     out_obj["type"]  = key
     if tag:
         out_obj["marker"] = tag
@@ -48,8 +55,9 @@ def usxtousj(input_usx_elmt):
         del out_obj['content']
     if "eid" in out_obj and key in ['verse', 'chapter']:
         action = "ignore"
-    # May need some special handling for va vp, ca cp elements.
-    # Now the USX samples in testsuite are not correct
+    if len(alt_pub_numbers)>0:
+        out_obj = [out_obj] + alt_pub_numbers
+        action = "merge"
     return out_obj, action
 
 def usjtousx(adict, elfactory=None):

--- a/python/scripts/usx2usj.py
+++ b/python/scripts/usx2usj.py
@@ -2,7 +2,7 @@ import argparse
 import json
 from lxml import etree
 
-VERSION_NUM = "0.2.3"
+VERSION_NUM = "0.2.4"
 SPEC_NAME = "USJ" # for Unified Scripture JSON
 
 def convert_usx(input_usx_elmt):
@@ -15,6 +15,7 @@ def convert_usx(input_usx_elmt):
     out_obj = {}
     action = "append"
     attribs = dict(input_usx_elmt.attrib)
+    alt_pub_numbers = []
     tag = None
     if "style" in attribs:
         tag = attribs['style']
@@ -25,6 +26,12 @@ def convert_usx(input_usx_elmt):
         del attribs['closed']
     if "status" in attribs:
         del attribs['status']
+    if "altnumber" in attribs:
+        alt_pub_numbers.append({'type':'char', "marker": f"{tag}a", "content":[attribs['altnumber']]})
+        del attribs['altnumber']
+    if "pubnumber" in attribs:
+        alt_pub_numbers.append({'type':'para', "marker": f"{tag}p", "content":[attribs['pubnumber']]})
+        del attribs['pubnumber']
     out_obj["type"]  = key
     if tag:
         out_obj["marker"] = tag
@@ -53,8 +60,9 @@ def convert_usx(input_usx_elmt):
         del out_obj['content']
     if "eid" in out_obj and key in ['verse', 'chapter']:
         action = "ignore"
-    # May need some special handling for va vp, ca cp elements.
-    # Now the USX samples in testsuite are not correct
+    if len(alt_pub_numbers)>0:
+        out_obj = [out_obj] + alt_pub_numbers
+        action = "merge"
     return out_obj, action
 
 def usx_to_json(input_usx):

--- a/python/scripts/usx2usj.py
+++ b/python/scripts/usx2usj.py
@@ -2,7 +2,7 @@ import argparse
 import json
 from lxml import etree
 
-VERSION_NUM = "0.2.1"
+VERSION_NUM = "0.2.3"
 SPEC_NAME = "USJ" # for Unified Scripture JSON
 
 def convert_usx(input_usx_elmt):

--- a/tests/advanced/custom-attributes/origin.json
+++ b/tests/advanced/custom-attributes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/advanced/custom-attributes/origin.json
+++ b/tests/advanced/custom-attributes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/advanced/default-attributes/origin.json
+++ b/tests/advanced/default-attributes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/advanced/default-attributes/origin.json
+++ b/tests/advanced/default-attributes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/advanced/header/origin.json
+++ b/tests/advanced/header/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/advanced/header/origin.json
+++ b/tests/advanced/header/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/advanced/list/origin.json
+++ b/tests/advanced/list/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/advanced/list/origin.json
+++ b/tests/advanced/list/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/advanced/milestones/origin.json
+++ b/tests/advanced/milestones/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/advanced/milestones/origin.json
+++ b/tests/advanced/milestones/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/advanced/nesting/origin.json
+++ b/tests/advanced/nesting/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/advanced/nesting/origin.json
+++ b/tests/advanced/nesting/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/advanced/nesting1/origin.json
+++ b/tests/advanced/nesting1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/advanced/nesting1/origin.json
+++ b/tests/advanced/nesting1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/advanced/periph/origin.json
+++ b/tests/advanced/periph/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/advanced/periph/origin.json
+++ b/tests/advanced/periph/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/basic/attributes/origin.json
+++ b/tests/basic/attributes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/basic/attributes/origin.json
+++ b/tests/basic/attributes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/basic/character/origin.json
+++ b/tests/basic/character/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/basic/character/origin.json
+++ b/tests/basic/character/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/basic/cross-refs/origin.json
+++ b/tests/basic/cross-refs/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/basic/cross-refs/origin.json
+++ b/tests/basic/cross-refs/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/basic/footnote/origin.json
+++ b/tests/basic/footnote/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/basic/footnote/origin.json
+++ b/tests/basic/footnote/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/basic/header/origin.json
+++ b/tests/basic/header/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/basic/header/origin.json
+++ b/tests/basic/header/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/basic/minimal/origin.json
+++ b/tests/basic/minimal/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/basic/minimal/origin.json
+++ b/tests/basic/minimal/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/basic/multiple-chapters/origin.json
+++ b/tests/basic/multiple-chapters/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/basic/multiple-chapters/origin.json
+++ b/tests/basic/multiple-chapters/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/basic/multiple-paragraphs/origin.json
+++ b/tests/basic/multiple-paragraphs/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/basic/multiple-paragraphs/origin.json
+++ b/tests/basic/multiple-paragraphs/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/basic/section/origin.json
+++ b/tests/basic/section/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/basic/section/origin.json
+++ b/tests/basic/section/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/biblica/BlankLinesWithFigures/origin.json
+++ b/tests/biblica/BlankLinesWithFigures/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/biblica/BlankLinesWithFigures/origin.json
+++ b/tests/biblica/BlankLinesWithFigures/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/biblica/PublishingVersesWithFormatting/origin.json
+++ b/tests/biblica/PublishingVersesWithFormatting/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/biblica/PublishingVersesWithFormatting/origin.json
+++ b/tests/biblica/PublishingVersesWithFormatting/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/introductions/bad/test1/origin.json
+++ b/tests/introductions/bad/test1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/introductions/bad/test1/origin.json
+++ b/tests/introductions/bad/test1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/mandatory/emptyV/origin.json
+++ b/tests/mandatory/emptyV/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/mandatory/emptyV/origin.json
+++ b/tests/mandatory/emptyV/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/mandatory/id/origin.json
+++ b/tests/mandatory/id/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "chapter",

--- a/tests/mandatory/id/origin.json
+++ b/tests/mandatory/id/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "chapter",

--- a/tests/mandatory/minimum/origin.json
+++ b/tests/mandatory/minimum/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/mandatory/minimum/origin.json
+++ b/tests/mandatory/minimum/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/mandatory/v/origin.json
+++ b/tests/mandatory/v/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/mandatory/v/origin.json
+++ b/tests/mandatory/v/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/CharStyleClosedAndReopened/origin.json
+++ b/tests/paratextTests/CharStyleClosedAndReopened/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/CharStyleClosedAndReopened/origin.json
+++ b/tests/paratextTests/CharStyleClosedAndReopened/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/CharStyleCrossesFootnote/origin.json
+++ b/tests/paratextTests/CharStyleCrossesFootnote/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/CharStyleCrossesFootnote/origin.json
+++ b/tests/paratextTests/CharStyleCrossesFootnote/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/CharStyleCrossesVerseNumber/origin.json
+++ b/tests/paratextTests/CharStyleCrossesVerseNumber/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/CharStyleCrossesVerseNumber/origin.json
+++ b/tests/paratextTests/CharStyleCrossesVerseNumber/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/CharStyleNotClosed/origin.json
+++ b/tests/paratextTests/CharStyleNotClosed/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/CharStyleNotClosed/origin.json
+++ b/tests/paratextTests/CharStyleNotClosed/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/CrossReferencesInsideCharacterMarker/origin.json
+++ b/tests/paratextTests/CrossReferencesInsideCharacterMarker/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/CrossReferencesInsideCharacterMarker/origin.json
+++ b/tests/paratextTests/CrossReferencesInsideCharacterMarker/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/CustomAttributesAreValid/origin.json
+++ b/tests/paratextTests/CustomAttributesAreValid/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/CustomAttributesAreValid/origin.json
+++ b/tests/paratextTests/CustomAttributesAreValid/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/EmptyFigure/origin.json
+++ b/tests/paratextTests/EmptyFigure/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/EmptyFigure/origin.json
+++ b/tests/paratextTests/EmptyFigure/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/EmptyMarkers/origin.json
+++ b/tests/paratextTests/EmptyMarkers/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/EmptyMarkers/origin.json
+++ b/tests/paratextTests/EmptyMarkers/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/FigureAttributesAreValid/origin.json
+++ b/tests/paratextTests/FigureAttributesAreValid/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/FigureAttributesAreValid/origin.json
+++ b/tests/paratextTests/FigureAttributesAreValid/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/FigureNotClosed/origin.json
+++ b/tests/paratextTests/FigureNotClosed/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/FigureNotClosed/origin.json
+++ b/tests/paratextTests/FigureNotClosed/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/FootnoteConsistencyCheck/origin.json
+++ b/tests/paratextTests/FootnoteConsistencyCheck/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/FootnoteConsistencyCheck/origin.json
+++ b/tests/paratextTests/FootnoteConsistencyCheck/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/FootnoteNotClosed/origin.json
+++ b/tests/paratextTests/FootnoteNotClosed/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/FootnoteNotClosed/origin.json
+++ b/tests/paratextTests/FootnoteNotClosed/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/FootnoteWithWrongSpacingAroundCaller/origin.json
+++ b/tests/paratextTests/FootnoteWithWrongSpacingAroundCaller/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/FootnoteWithWrongSpacingAroundCaller/origin.json
+++ b/tests/paratextTests/FootnoteWithWrongSpacingAroundCaller/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/GlossaryCitationFormContainingWordMedialPunctuation_Pass/origin.json
+++ b/tests/paratextTests/GlossaryCitationFormContainingWordMedialPunctuation_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/GlossaryCitationFormContainingWordMedialPunctuation_Pass/origin.json
+++ b/tests/paratextTests/GlossaryCitationFormContainingWordMedialPunctuation_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/GlossaryCitationFormContainsComma_Pass/origin.json
+++ b/tests/paratextTests/GlossaryCitationFormContainsComma_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/GlossaryCitationFormContainsComma_Pass/origin.json
+++ b/tests/paratextTests/GlossaryCitationFormContainsComma_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/GlossaryCitationFormContainsNonWordformingPunctuation/origin.json
+++ b/tests/paratextTests/GlossaryCitationFormContainsNonWordformingPunctuation/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/GlossaryCitationFormContainsNonWordformingPunctuation/origin.json
+++ b/tests/paratextTests/GlossaryCitationFormContainsNonWordformingPunctuation/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/GlossaryCitationFormEndsInPunctuation/origin.json
+++ b/tests/paratextTests/GlossaryCitationFormEndsInPunctuation/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/GlossaryCitationFormEndsInPunctuation/origin.json
+++ b/tests/paratextTests/GlossaryCitationFormEndsInPunctuation/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/GlossaryCitationFormEndsInSpace/origin.json
+++ b/tests/paratextTests/GlossaryCitationFormEndsInSpace/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/GlossaryCitationFormEndsInSpace/origin.json
+++ b/tests/paratextTests/GlossaryCitationFormEndsInSpace/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/GlossaryCitationFormEndsWithParentheses_Pass/origin.json
+++ b/tests/paratextTests/GlossaryCitationFormEndsWithParentheses_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/GlossaryCitationFormEndsWithParentheses_Pass/origin.json
+++ b/tests/paratextTests/GlossaryCitationFormEndsWithParentheses_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/GlossaryCitationFormMultipleWords_Pass/origin.json
+++ b/tests/paratextTests/GlossaryCitationFormMultipleWords_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/GlossaryCitationFormMultipleWords_Pass/origin.json
+++ b/tests/paratextTests/GlossaryCitationFormMultipleWords_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/GlossaryCitationForm_Pass/origin.json
+++ b/tests/paratextTests/GlossaryCitationForm_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/GlossaryCitationForm_Pass/origin.json
+++ b/tests/paratextTests/GlossaryCitationForm_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/GlossaryNoKeywordErrors/origin.json
+++ b/tests/paratextTests/GlossaryNoKeywordErrors/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/GlossaryNoKeywordErrors/origin.json
+++ b/tests/paratextTests/GlossaryNoKeywordErrors/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/IdMarkerInMiddleOfBook/origin.json
+++ b/tests/paratextTests/IdMarkerInMiddleOfBook/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/IdMarkerInMiddleOfBook/origin.json
+++ b/tests/paratextTests/IdMarkerInMiddleOfBook/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/IgnoreKeywordErrorsOutsideOfGlossary/origin.json
+++ b/tests/paratextTests/IgnoreKeywordErrorsOutsideOfGlossary/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/IgnoreKeywordErrorsOutsideOfGlossary/origin.json
+++ b/tests/paratextTests/IgnoreKeywordErrorsOutsideOfGlossary/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/InvalidAttributeValuesReported/origin.json
+++ b/tests/paratextTests/InvalidAttributeValuesReported/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/InvalidAttributeValuesReported/origin.json
+++ b/tests/paratextTests/InvalidAttributeValuesReported/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/InvalidAttributes/origin.json
+++ b/tests/paratextTests/InvalidAttributes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/InvalidAttributes/origin.json
+++ b/tests/paratextTests/InvalidAttributes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/InvalidFigureAttributesReported/origin.json
+++ b/tests/paratextTests/InvalidFigureAttributesReported/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/InvalidFigureAttributesReported/origin.json
+++ b/tests/paratextTests/InvalidFigureAttributesReported/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/InvalidMarker/origin.json
+++ b/tests/paratextTests/InvalidMarker/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/InvalidMarker/origin.json
+++ b/tests/paratextTests/InvalidMarker/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/InvalidMilestone_EndWithoutStart/origin.json
+++ b/tests/paratextTests/InvalidMilestone_EndWithoutStart/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/InvalidMilestone_EndWithoutStart/origin.json
+++ b/tests/paratextTests/InvalidMilestone_EndWithoutStart/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/InvalidMilestone_IdsDontMatch/origin.json
+++ b/tests/paratextTests/InvalidMilestone_IdsDontMatch/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/InvalidMilestone_IdsDontMatch/origin.json
+++ b/tests/paratextTests/InvalidMilestone_IdsDontMatch/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/InvalidMilestone_MissingEnd/origin.json
+++ b/tests/paratextTests/InvalidMilestone_MissingEnd/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/InvalidMilestone_MissingEnd/origin.json
+++ b/tests/paratextTests/InvalidMilestone_MissingEnd/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/InvalidRubyMarkup/origin.json
+++ b/tests/paratextTests/InvalidRubyMarkup/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/InvalidRubyMarkup/origin.json
+++ b/tests/paratextTests/InvalidRubyMarkup/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/InvalidUsfm20Usage/origin.json
+++ b/tests/paratextTests/InvalidUsfm20Usage/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/InvalidUsfm20Usage/origin.json
+++ b/tests/paratextTests/InvalidUsfm20Usage/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/LinkAttributesAreValid/origin.json
+++ b/tests/paratextTests/LinkAttributesAreValid/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/LinkAttributesAreValid/origin.json
+++ b/tests/paratextTests/LinkAttributesAreValid/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/MajorTitleRequired/origin.json
+++ b/tests/paratextTests/MajorTitleRequired/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/MajorTitleRequired/origin.json
+++ b/tests/paratextTests/MajorTitleRequired/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/MarkersMissingSpace/origin.json
+++ b/tests/paratextTests/MarkersMissingSpace/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/MarkersMissingSpace/origin.json
+++ b/tests/paratextTests/MarkersMissingSpace/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/MissingColumnInTable/origin.json
+++ b/tests/paratextTests/MissingColumnInTable/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/MissingColumnInTable/origin.json
+++ b/tests/paratextTests/MissingColumnInTable/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/MissingIdAndChapterMarkers/origin.json
+++ b/tests/paratextTests/MissingIdAndChapterMarkers/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "para",

--- a/tests/paratextTests/MissingIdAndChapterMarkers/origin.json
+++ b/tests/paratextTests/MissingIdAndChapterMarkers/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "para",

--- a/tests/paratextTests/MissingIdMarker/origin.json
+++ b/tests/paratextTests/MissingIdMarker/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "chapter",

--- a/tests/paratextTests/MissingIdMarker/origin.json
+++ b/tests/paratextTests/MissingIdMarker/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "chapter",

--- a/tests/paratextTests/MissingRequiredAttributesReported/origin.json
+++ b/tests/paratextTests/MissingRequiredAttributesReported/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/MissingRequiredAttributesReported/origin.json
+++ b/tests/paratextTests/MissingRequiredAttributesReported/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/NbMarkerInCorrectPlace/origin.json
+++ b/tests/paratextTests/NbMarkerInCorrectPlace/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/NbMarkerInCorrectPlace/origin.json
+++ b/tests/paratextTests/NbMarkerInCorrectPlace/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/NestingInCrossReferences/origin.json
+++ b/tests/paratextTests/NestingInCrossReferences/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/NestingInCrossReferences/origin.json
+++ b/tests/paratextTests/NestingInCrossReferences/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/NestingInFootnote/origin.json
+++ b/tests/paratextTests/NestingInFootnote/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/NestingInFootnote/origin.json
+++ b/tests/paratextTests/NestingInFootnote/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/NestingUnclosed/origin.json
+++ b/tests/paratextTests/NestingUnclosed/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/NestingUnclosed/origin.json
+++ b/tests/paratextTests/NestingUnclosed/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/NoErrorsEmptyBook/origin.json
+++ b/tests/paratextTests/NoErrorsEmptyBook/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/NoErrorsEmptyBook/origin.json
+++ b/tests/paratextTests/NoErrorsEmptyBook/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/NoErrorsNesting/origin.json
+++ b/tests/paratextTests/NoErrorsNesting/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/NoErrorsNesting/origin.json
+++ b/tests/paratextTests/NoErrorsNesting/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/NoErrorsPartiallyEmptyBook/origin.json
+++ b/tests/paratextTests/NoErrorsPartiallyEmptyBook/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/NoErrorsPartiallyEmptyBook/origin.json
+++ b/tests/paratextTests/NoErrorsPartiallyEmptyBook/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/NoErrorsShort/origin.json
+++ b/tests/paratextTests/NoErrorsShort/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/NoErrorsShort/origin.json
+++ b/tests/paratextTests/NoErrorsShort/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/NoErrosLong/origin.json
+++ b/tests/paratextTests/NoErrosLong/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/NoErrosLong/origin.json
+++ b/tests/paratextTests/NoErrosLong/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/OnlyChapterAndVerseMarkers/origin.json
+++ b/tests/paratextTests/OnlyChapterAndVerseMarkers/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/OnlyChapterAndVerseMarkers/origin.json
+++ b/tests/paratextTests/OnlyChapterAndVerseMarkers/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/UnmatchedSidebarEnd/origin.json
+++ b/tests/paratextTests/UnmatchedSidebarEnd/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/UnmatchedSidebarEnd/origin.json
+++ b/tests/paratextTests/UnmatchedSidebarEnd/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/UnmatchedSidebarStart/origin.json
+++ b/tests/paratextTests/UnmatchedSidebarStart/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/UnmatchedSidebarStart/origin.json
+++ b/tests/paratextTests/UnmatchedSidebarStart/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/ValidMilestones/origin.json
+++ b/tests/paratextTests/ValidMilestones/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/ValidMilestones/origin.json
+++ b/tests/paratextTests/ValidMilestones/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/ValidRubyMarkup/origin.json
+++ b/tests/paratextTests/ValidRubyMarkup/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/ValidRubyMarkup/origin.json
+++ b/tests/paratextTests/ValidRubyMarkup/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerKeywordContainsComma_Pass/origin.json
+++ b/tests/paratextTests/WordlistMarkerKeywordContainsComma_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerKeywordContainsComma_Pass/origin.json
+++ b/tests/paratextTests/WordlistMarkerKeywordContainsComma_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerKeywordContainsNonWordformingPunctuation/origin.json
+++ b/tests/paratextTests/WordlistMarkerKeywordContainsNonWordformingPunctuation/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerKeywordContainsNonWordformingPunctuation/origin.json
+++ b/tests/paratextTests/WordlistMarkerKeywordContainsNonWordformingPunctuation/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerKeywordEndsInPunctuation/origin.json
+++ b/tests/paratextTests/WordlistMarkerKeywordEndsInPunctuation/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerKeywordEndsInPunctuation/origin.json
+++ b/tests/paratextTests/WordlistMarkerKeywordEndsInPunctuation/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerKeywordEndsInSpace/origin.json
+++ b/tests/paratextTests/WordlistMarkerKeywordEndsInSpace/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerKeywordEndsInSpace/origin.json
+++ b/tests/paratextTests/WordlistMarkerKeywordEndsInSpace/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerKeywordEndsInSpaceGlossaryEntryPresent_Pass/origin.json
+++ b/tests/paratextTests/WordlistMarkerKeywordEndsInSpaceGlossaryEntryPresent_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerKeywordEndsInSpaceGlossaryEntryPresent_Pass/origin.json
+++ b/tests/paratextTests/WordlistMarkerKeywordEndsInSpaceGlossaryEntryPresent_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerKeywordWithParentheses_Pass/origin.json
+++ b/tests/paratextTests/WordlistMarkerKeywordWithParentheses_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerKeywordWithParentheses_Pass/origin.json
+++ b/tests/paratextTests/WordlistMarkerKeywordWithParentheses_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerMissingFromGlossaryCitationForms/origin.json
+++ b/tests/paratextTests/WordlistMarkerMissingFromGlossaryCitationForms/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerMissingFromGlossaryCitationForms/origin.json
+++ b/tests/paratextTests/WordlistMarkerMissingFromGlossaryCitationForms/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerNestedProperNounWithKeyword_Pass/origin.json
+++ b/tests/paratextTests/WordlistMarkerNestedProperNounWithKeyword_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerNestedProperNounWithKeyword_Pass/origin.json
+++ b/tests/paratextTests/WordlistMarkerNestedProperNounWithKeyword_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerNestedProperNoun_Pass/origin.json
+++ b/tests/paratextTests/WordlistMarkerNestedProperNoun_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerNestedProperNoun_Pass/origin.json
+++ b/tests/paratextTests/WordlistMarkerNestedProperNoun_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerNestedShouldNotIncludeKeyword/origin.json
+++ b/tests/paratextTests/WordlistMarkerNestedShouldNotIncludeKeyword/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerNestedShouldNotIncludeKeyword/origin.json
+++ b/tests/paratextTests/WordlistMarkerNestedShouldNotIncludeKeyword/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerNestedTwoProperNouns_Pass/origin.json
+++ b/tests/paratextTests/WordlistMarkerNestedTwoProperNouns_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerNestedTwoProperNouns_Pass/origin.json
+++ b/tests/paratextTests/WordlistMarkerNestedTwoProperNouns_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerTextContainsNonWordformingPunctuation/origin.json
+++ b/tests/paratextTests/WordlistMarkerTextContainsNonWordformingPunctuation/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerTextContainsNonWordformingPunctuation/origin.json
+++ b/tests/paratextTests/WordlistMarkerTextContainsNonWordformingPunctuation/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerTextEndsInPunctuation/origin.json
+++ b/tests/paratextTests/WordlistMarkerTextEndsInPunctuation/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerTextEndsInPunctuation/origin.json
+++ b/tests/paratextTests/WordlistMarkerTextEndsInPunctuation/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerTextEndsInSpaceAndMissingFromGlossary/origin.json
+++ b/tests/paratextTests/WordlistMarkerTextEndsInSpaceAndMissingFromGlossary/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerTextEndsInSpaceAndMissingFromGlossary/origin.json
+++ b/tests/paratextTests/WordlistMarkerTextEndsInSpaceAndMissingFromGlossary/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerTextEndsInSpaceGlossaryEntryPresent_Pass/origin.json
+++ b/tests/paratextTests/WordlistMarkerTextEndsInSpaceGlossaryEntryPresent_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerTextEndsInSpaceGlossaryEntryPresent_Pass/origin.json
+++ b/tests/paratextTests/WordlistMarkerTextEndsInSpaceGlossaryEntryPresent_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerTextEndsInSpaceWithGlossary/origin.json
+++ b/tests/paratextTests/WordlistMarkerTextEndsInSpaceWithGlossary/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerTextEndsInSpaceWithGlossary/origin.json
+++ b/tests/paratextTests/WordlistMarkerTextEndsInSpaceWithGlossary/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerTextEndsInSpaceWithoutGlossary/origin.json
+++ b/tests/paratextTests/WordlistMarkerTextEndsInSpaceWithoutGlossary/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerTextEndsInSpaceWithoutGlossary/origin.json
+++ b/tests/paratextTests/WordlistMarkerTextEndsInSpaceWithoutGlossary/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerWithKeyword_Pass/origin.json
+++ b/tests/paratextTests/WordlistMarkerWithKeyword_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerWithKeyword_Pass/origin.json
+++ b/tests/paratextTests/WordlistMarkerWithKeyword_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/WEB1/origin.json
+++ b/tests/samples-from-wild/WEB1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/WEB1/origin.json
+++ b/tests/samples-from-wild/WEB1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/WEB2/origin.json
+++ b/tests/samples-from-wild/WEB2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/WEB2/origin.json
+++ b/tests/samples-from-wild/WEB2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/WEB3/origin.json
+++ b/tests/samples-from-wild/WEB3/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/WEB3/origin.json
+++ b/tests/samples-from-wild/WEB3/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/brenton1/origin.json
+++ b/tests/samples-from-wild/brenton1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/brenton1/origin.json
+++ b/tests/samples-from-wild/brenton1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/brenton2/origin.json
+++ b/tests/samples-from-wild/brenton2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/brenton2/origin.json
+++ b/tests/samples-from-wild/brenton2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/chinese1/origin.json
+++ b/tests/samples-from-wild/chinese1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/chinese1/origin.json
+++ b/tests/samples-from-wild/chinese1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/chinese2/origin.json
+++ b/tests/samples-from-wild/chinese2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/chinese2/origin.json
+++ b/tests/samples-from-wild/chinese2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/chinese3/origin.json
+++ b/tests/samples-from-wild/chinese3/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/chinese3/origin.json
+++ b/tests/samples-from-wild/chinese3/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/doo43-1/origin.json
+++ b/tests/samples-from-wild/doo43-1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/doo43-1/origin.json
+++ b/tests/samples-from-wild/doo43-1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/doo43-3/origin.json
+++ b/tests/samples-from-wild/doo43-3/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/doo43-3/origin.json
+++ b/tests/samples-from-wild/doo43-3/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/doo43-4/origin.json
+++ b/tests/samples-from-wild/doo43-4/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/doo43-4/origin.json
+++ b/tests/samples-from-wild/doo43-4/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/hindi-IRV1/origin.json
+++ b/tests/samples-from-wild/hindi-IRV1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/hindi-IRV1/origin.json
+++ b/tests/samples-from-wild/hindi-IRV1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/hindi-IRV2/origin.json
+++ b/tests/samples-from-wild/hindi-IRV2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/hindi-IRV2/origin.json
+++ b/tests/samples-from-wild/hindi-IRV2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/rv2/origin.json
+++ b/tests/samples-from-wild/rv2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/rv2/origin.json
+++ b/tests/samples-from-wild/rv2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/rv3/origin.json
+++ b/tests/samples-from-wild/rv3/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/rv3/origin.json
+++ b/tests/samples-from-wild/rv3/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/t4t1/origin.json
+++ b/tests/samples-from-wild/t4t1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/t4t1/origin.json
+++ b/tests/samples-from-wild/t4t1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/t4t3/origin.json
+++ b/tests/samples-from-wild/t4t3/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/t4t3/origin.json
+++ b/tests/samples-from-wild/t4t3/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/ta2il-IRV1/origin.json
+++ b/tests/samples-from-wild/ta2il-IRV1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/ta2il-IRV1/origin.json
+++ b/tests/samples-from-wild/ta2il-IRV1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/tamil-IRV1/origin.json
+++ b/tests/samples-from-wild/tamil-IRV1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/tamil-IRV1/origin.json
+++ b/tests/samples-from-wild/tamil-IRV1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/attributes/origin.json
+++ b/tests/specExamples/attributes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/attributes/origin.json
+++ b/tests/specExamples/attributes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/chapter-verse/origin.json
+++ b/tests/specExamples/chapter-verse/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",
@@ -14,9 +14,21 @@
       "type": "chapter",
       "marker": "c",
       "number": "1",
-      "altnumber": "2",
-      "pubnumber": "M",
       "sid": "MAT 1"
+    },
+    {
+      "type": "char",
+      "marker": "ca",
+      "content": [
+        "2"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "cp",
+      "content": [
+        "M"
+      ]
     },
     {
       "type": "para",
@@ -54,9 +66,21 @@
           "type": "verse",
           "marker": "v",
           "number": "1",
-          "altnumber": "3",
-          "sid": "MAT 1:1",
-          "pubnumber": "1b"
+          "sid": "MAT 1:1"
+        },
+        {
+          "type": "char",
+          "marker": "va",
+          "content": [
+            "3"
+          ]
+        },
+        {
+          "type": "para",
+          "marker": "vp",
+          "content": [
+            "1b"
+          ]
         },
         "This is the list of the ancestors of Jesus Christ, a descendant of David, who was a descendant of Abraham."
       ]

--- a/tests/specExamples/chapter-verse/origin.json
+++ b/tests/specExamples/chapter-verse/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/character/origin.json
+++ b/tests/specExamples/character/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/character/origin.json
+++ b/tests/specExamples/character/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/cross-ref/origin.json
+++ b/tests/specExamples/cross-ref/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/cross-ref/origin.json
+++ b/tests/specExamples/cross-ref/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/extended/bookIntroductions1/origin.json
+++ b/tests/specExamples/extended/bookIntroductions1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/extended/bookIntroductions1/origin.json
+++ b/tests/specExamples/extended/bookIntroductions1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/extended/bookIntroductions2/origin.json
+++ b/tests/specExamples/extended/bookIntroductions2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/extended/bookIntroductions2/origin.json
+++ b/tests/specExamples/extended/bookIntroductions2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/extended/contentCatogories1/origin.json
+++ b/tests/specExamples/extended/contentCatogories1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/extended/contentCatogories1/origin.json
+++ b/tests/specExamples/extended/contentCatogories1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/extended/contentCatogories2/origin.json
+++ b/tests/specExamples/extended/contentCatogories2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/extended/contentCatogories2/origin.json
+++ b/tests/specExamples/extended/contentCatogories2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/extended/footnotes/origin.json
+++ b/tests/specExamples/extended/footnotes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/extended/footnotes/origin.json
+++ b/tests/specExamples/extended/footnotes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/extended/sectionIntroductions/origin.json
+++ b/tests/specExamples/extended/sectionIntroductions/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/extended/sectionIntroductions/origin.json
+++ b/tests/specExamples/extended/sectionIntroductions/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/extended/sidebars/origin.json
+++ b/tests/specExamples/extended/sidebars/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/extended/sidebars/origin.json
+++ b/tests/specExamples/extended/sidebars/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/footnote/origin.json
+++ b/tests/specExamples/footnote/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/footnote/origin.json
+++ b/tests/specExamples/footnote/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/identification/origin.json
+++ b/tests/specExamples/identification/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/identification/origin.json
+++ b/tests/specExamples/identification/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/introduction1/origin.json
+++ b/tests/specExamples/introduction1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/introduction1/origin.json
+++ b/tests/specExamples/introduction1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/introduction2/origin.json
+++ b/tests/specExamples/introduction2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/introduction2/origin.json
+++ b/tests/specExamples/introduction2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/introduction3/origin.json
+++ b/tests/specExamples/introduction3/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/introduction3/origin.json
+++ b/tests/specExamples/introduction3/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/list/origin.json
+++ b/tests/specExamples/list/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/list/origin.json
+++ b/tests/specExamples/list/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/milestone/origin.json
+++ b/tests/specExamples/milestone/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/milestone/origin.json
+++ b/tests/specExamples/milestone/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/paragraph/origin.json
+++ b/tests/specExamples/paragraph/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/paragraph/origin.json
+++ b/tests/specExamples/paragraph/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/poetry/origin.json
+++ b/tests/specExamples/poetry/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/poetry/origin.json
+++ b/tests/specExamples/poetry/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/table/origin.json
+++ b/tests/specExamples/table/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/table/origin.json
+++ b/tests/specExamples/table/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/titles/origin.json
+++ b/tests/specExamples/titles/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/titles/origin.json
+++ b/tests/specExamples/titles/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/IRV1/origin.json
+++ b/tests/special-cases/IRV1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/IRV1/origin.json
+++ b/tests/special-cases/IRV1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/IRV2/origin.json
+++ b/tests/special-cases/IRV2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/IRV2/origin.json
+++ b/tests/special-cases/IRV2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/IRV3/origin.json
+++ b/tests/special-cases/IRV3/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/IRV3/origin.json
+++ b/tests/special-cases/IRV3/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/IRV4/origin.json
+++ b/tests/special-cases/IRV4/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/IRV4/origin.json
+++ b/tests/special-cases/IRV4/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/IRV5/origin.json
+++ b/tests/special-cases/IRV5/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/IRV5/origin.json
+++ b/tests/special-cases/IRV5/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/IRV6/origin.json
+++ b/tests/special-cases/IRV6/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/IRV6/origin.json
+++ b/tests/special-cases/IRV6/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/IRV7/origin.json
+++ b/tests/special-cases/IRV7/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/IRV7/origin.json
+++ b/tests/special-cases/IRV7/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/IRV8/origin.json
+++ b/tests/special-cases/IRV8/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/IRV8/origin.json
+++ b/tests/special-cases/IRV8/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/IRV9/origin.json
+++ b/tests/special-cases/IRV9/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/IRV9/origin.json
+++ b/tests/special-cases/IRV9/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-attributes/origin.json
+++ b/tests/special-cases/empty-attributes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-attributes/origin.json
+++ b/tests/special-cases/empty-attributes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-attributes2/origin.json
+++ b/tests/special-cases/empty-attributes2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-attributes2/origin.json
+++ b/tests/special-cases/empty-attributes2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-attributes3/origin.json
+++ b/tests/special-cases/empty-attributes3/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-attributes3/origin.json
+++ b/tests/special-cases/empty-attributes3/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-attributes4/origin.json
+++ b/tests/special-cases/empty-attributes4/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-attributes4/origin.json
+++ b/tests/special-cases/empty-attributes4/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-attributes5/origin.json
+++ b/tests/special-cases/empty-attributes5/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-attributes5/origin.json
+++ b/tests/special-cases/empty-attributes5/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-book/origin.json
+++ b/tests/special-cases/empty-book/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-book/origin.json
+++ b/tests/special-cases/empty-book/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-c/origin.json
+++ b/tests/special-cases/empty-c/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-c/origin.json
+++ b/tests/special-cases/empty-c/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-li/origin.json
+++ b/tests/special-cases/empty-li/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-li/origin.json
+++ b/tests/special-cases/empty-li/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-lines/origin.json
+++ b/tests/special-cases/empty-lines/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-lines/origin.json
+++ b/tests/special-cases/empty-lines/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-para/origin.json
+++ b/tests/special-cases/empty-para/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-para/origin.json
+++ b/tests/special-cases/empty-para/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-para2/origin.json
+++ b/tests/special-cases/empty-para2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-para2/origin.json
+++ b/tests/special-cases/empty-para2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/figure_with_quotes_in_desc/origin.json
+++ b/tests/special-cases/figure_with_quotes_in_desc/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/figure_with_quotes_in_desc/origin.json
+++ b/tests/special-cases/figure_with_quotes_in_desc/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/id-in-text/origin.json
+++ b/tests/special-cases/id-in-text/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/id-in-text/origin.json
+++ b/tests/special-cases/id-in-text/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/nbsp/origin.json
+++ b/tests/special-cases/nbsp/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/nbsp/origin.json
+++ b/tests/special-cases/nbsp/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/nested-notes/origin.json
+++ b/tests/special-cases/nested-notes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/nested-notes/origin.json
+++ b/tests/special-cases/nested-notes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/nesting/origin.json
+++ b/tests/special-cases/nesting/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/nesting/origin.json
+++ b/tests/special-cases/nesting/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/newline-attributes/origin.json
+++ b/tests/special-cases/newline-attributes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/newline-attributes/origin.json
+++ b/tests/special-cases/newline-attributes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/notes/origin.json
+++ b/tests/special-cases/notes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/notes/origin.json
+++ b/tests/special-cases/notes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/notes2/origin.json
+++ b/tests/special-cases/notes2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/notes2/origin.json
+++ b/tests/special-cases/notes2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/pi/origin.json
+++ b/tests/special-cases/pi/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/pi/origin.json
+++ b/tests/special-cases/pi/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/punct-at-break/origin.json
+++ b/tests/special-cases/punct-at-break/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/punct-at-break/origin.json
+++ b/tests/special-cases/punct-at-break/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/qa/origin.json
+++ b/tests/special-cases/qa/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/qa/origin.json
+++ b/tests/special-cases/qa/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/sp/origin.json
+++ b/tests/special-cases/sp/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/sp/origin.json
+++ b/tests/special-cases/sp/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/1ch_verse_span/origin.json
+++ b/tests/usfmjsTests/1ch_verse_span/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/1ch_verse_span/origin.json
+++ b/tests/usfmjsTests/1ch_verse_span/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/57-TIT.greek/origin.json
+++ b/tests/usfmjsTests/57-TIT.greek/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/57-TIT.greek/origin.json
+++ b/tests/usfmjsTests/57-TIT.greek/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/57-TIT.partial/origin.json
+++ b/tests/usfmjsTests/57-TIT.partial/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/57-TIT.partial/origin.json
+++ b/tests/usfmjsTests/57-TIT.partial/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/acts-1-20.aligned/origin.json
+++ b/tests/usfmjsTests/acts-1-20.aligned/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/acts-1-20.aligned/origin.json
+++ b/tests/usfmjsTests/acts-1-20.aligned/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/acts_1_11.aligned/origin.json
+++ b/tests/usfmjsTests/acts_1_11.aligned/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/acts_1_11.aligned/origin.json
+++ b/tests/usfmjsTests/acts_1_11.aligned/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/acts_1_11/origin.json
+++ b/tests/usfmjsTests/acts_1_11/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/acts_1_11/origin.json
+++ b/tests/usfmjsTests/acts_1_11/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/acts_1_4.aligned/origin.json
+++ b/tests/usfmjsTests/acts_1_4.aligned/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/acts_1_4.aligned/origin.json
+++ b/tests/usfmjsTests/acts_1_4.aligned/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/acts_1_4/origin.json
+++ b/tests/usfmjsTests/acts_1_4/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/acts_1_4/origin.json
+++ b/tests/usfmjsTests/acts_1_4/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/acts_1_milestone/origin.json
+++ b/tests/usfmjsTests/acts_1_milestone/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/acts_1_milestone/origin.json
+++ b/tests/usfmjsTests/acts_1_milestone/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/acts_8-37-ugnt-footnote/origin.json
+++ b/tests/usfmjsTests/acts_8-37-ugnt-footnote/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/acts_8-37-ugnt-footnote/origin.json
+++ b/tests/usfmjsTests/acts_8-37-ugnt-footnote/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/chunk/origin.json
+++ b/tests/usfmjsTests/chunk/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/chunk/origin.json
+++ b/tests/usfmjsTests/chunk/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/chunk_footnote/origin.json
+++ b/tests/usfmjsTests/chunk_footnote/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/chunk_footnote/origin.json
+++ b/tests/usfmjsTests/chunk_footnote/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/esb/origin.json
+++ b/tests/usfmjsTests/esb/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/esb/origin.json
+++ b/tests/usfmjsTests/esb/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/f10_gen12-2_empty_word/origin.json
+++ b/tests/usfmjsTests/f10_gen12-2_empty_word/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/f10_gen12-2_empty_word/origin.json
+++ b/tests/usfmjsTests/f10_gen12-2_empty_word/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/greek.oldformat/origin.json
+++ b/tests/usfmjsTests/greek.oldformat/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/greek.oldformat/origin.json
+++ b/tests/usfmjsTests/greek.oldformat/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/greek/origin.json
+++ b/tests/usfmjsTests/greek/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/greek/origin.json
+++ b/tests/usfmjsTests/greek/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/heb-12-27.grc/origin.json
+++ b/tests/usfmjsTests/heb-12-27.grc/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/heb-12-27.grc/origin.json
+++ b/tests/usfmjsTests/heb-12-27.grc/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/heb1-1_multi_alignment/origin.json
+++ b/tests/usfmjsTests/heb1-1_multi_alignment/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/heb1-1_multi_alignment/origin.json
+++ b/tests/usfmjsTests/heb1-1_multi_alignment/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/hebrew_words.oldformat/origin.json
+++ b/tests/usfmjsTests/hebrew_words.oldformat/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/hebrew_words.oldformat/origin.json
+++ b/tests/usfmjsTests/hebrew_words.oldformat/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/hebrew_words/origin.json
+++ b/tests/usfmjsTests/hebrew_words/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/hebrew_words/origin.json
+++ b/tests/usfmjsTests/hebrew_words/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/inline_God/origin.json
+++ b/tests/usfmjsTests/inline_God/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/inline_God/origin.json
+++ b/tests/usfmjsTests/inline_God/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/inline_words/origin.json
+++ b/tests/usfmjsTests/inline_words/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/inline_words/origin.json
+++ b/tests/usfmjsTests/inline_words/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/isa_footnote/origin.json
+++ b/tests/usfmjsTests/isa_footnote/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/isa_footnote/origin.json
+++ b/tests/usfmjsTests/isa_footnote/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/isa_inline_quotes/origin.json
+++ b/tests/usfmjsTests/isa_inline_quotes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/isa_inline_quotes/origin.json
+++ b/tests/usfmjsTests/isa_inline_quotes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/isa_verse_span/origin.json
+++ b/tests/usfmjsTests/isa_verse_span/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/isa_verse_span/origin.json
+++ b/tests/usfmjsTests/isa_verse_span/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/jmp/origin.json
+++ b/tests/usfmjsTests/jmp/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/jmp/origin.json
+++ b/tests/usfmjsTests/jmp/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/job_footnote/origin.json
+++ b/tests/usfmjsTests/job_footnote/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/job_footnote/origin.json
+++ b/tests/usfmjsTests/job_footnote/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/links/origin.json
+++ b/tests/usfmjsTests/links/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/links/origin.json
+++ b/tests/usfmjsTests/links/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/luk_quotes/origin.json
+++ b/tests/usfmjsTests/luk_quotes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/luk_quotes/origin.json
+++ b/tests/usfmjsTests/luk_quotes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/mat-4-6.whitespace/origin.json
+++ b/tests/usfmjsTests/mat-4-6.whitespace/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/mat-4-6.whitespace/origin.json
+++ b/tests/usfmjsTests/mat-4-6.whitespace/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/mat-4-6/origin.json
+++ b/tests/usfmjsTests/mat-4-6/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/mat-4-6/origin.json
+++ b/tests/usfmjsTests/mat-4-6/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/misc_footnotes/origin.json
+++ b/tests/usfmjsTests/misc_footnotes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/misc_footnotes/origin.json
+++ b/tests/usfmjsTests/misc_footnotes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/missing_verses/origin.json
+++ b/tests/usfmjsTests/missing_verses/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/missing_verses/origin.json
+++ b/tests/usfmjsTests/missing_verses/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/out_of_sequence_chapters/origin.json
+++ b/tests/usfmjsTests/out_of_sequence_chapters/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/out_of_sequence_chapters/origin.json
+++ b/tests/usfmjsTests/out_of_sequence_chapters/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/out_of_sequence_verses/origin.json
+++ b/tests/usfmjsTests/out_of_sequence_verses/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/out_of_sequence_verses/origin.json
+++ b/tests/usfmjsTests/out_of_sequence_verses/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/pro_footnote/origin.json
+++ b/tests/usfmjsTests/pro_footnote/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/pro_footnote/origin.json
+++ b/tests/usfmjsTests/pro_footnote/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/pro_quotes/origin.json
+++ b/tests/usfmjsTests/pro_quotes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/pro_quotes/origin.json
+++ b/tests/usfmjsTests/pro_quotes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/psa_quotes/origin.json
+++ b/tests/usfmjsTests/psa_quotes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/psa_quotes/origin.json
+++ b/tests/usfmjsTests/psa_quotes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/qt/origin.json
+++ b/tests/usfmjsTests/qt/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/qt/origin.json
+++ b/tests/usfmjsTests/qt/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tit1-1_alignment/origin.json
+++ b/tests/usfmjsTests/tit1-1_alignment/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tit1-1_alignment/origin.json
+++ b/tests/usfmjsTests/tit1-1_alignment/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tit1-1_alignment_strongs/origin.json
+++ b/tests/usfmjsTests/tit1-1_alignment_strongs/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tit1-1_alignment_strongs/origin.json
+++ b/tests/usfmjsTests/tit1-1_alignment_strongs/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tit_1_12.alignment/origin.json
+++ b/tests/usfmjsTests/tit_1_12.alignment/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tit_1_12.alignment/origin.json
+++ b/tests/usfmjsTests/tit_1_12.alignment/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tit_1_12.no.words/origin.json
+++ b/tests/usfmjsTests/tit_1_12.no.words/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tit_1_12.no.words/origin.json
+++ b/tests/usfmjsTests/tit_1_12.no.words/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tit_1_12.oldformat/origin.json
+++ b/tests/usfmjsTests/tit_1_12.oldformat/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tit_1_12.oldformat/origin.json
+++ b/tests/usfmjsTests/tit_1_12.oldformat/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tit_1_12.word.not.at.line.start/origin.json
+++ b/tests/usfmjsTests/tit_1_12.word.not.at.line.start/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tit_1_12.word.not.at.line.start/origin.json
+++ b/tests/usfmjsTests/tit_1_12.word.not.at.line.start/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tit_1_12/origin.json
+++ b/tests/usfmjsTests/tit_1_12/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tit_1_12/origin.json
+++ b/tests/usfmjsTests/tit_1_12/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tit_1_12_footnote/origin.json
+++ b/tests/usfmjsTests/tit_1_12_footnote/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tit_1_12_footnote/origin.json
+++ b/tests/usfmjsTests/tit_1_12_footnote/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tit_1_12_new_line/origin.json
+++ b/tests/usfmjsTests/tit_1_12_new_line/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tit_1_12_new_line/origin.json
+++ b/tests/usfmjsTests/tit_1_12_new_line/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tit_extra_space_after_chapter/origin.json
+++ b/tests/usfmjsTests/tit_extra_space_after_chapter/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tit_extra_space_after_chapter/origin.json
+++ b/tests/usfmjsTests/tit_extra_space_after_chapter/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/ts_2/origin.json
+++ b/tests/usfmjsTests/ts_2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/ts_2/origin.json
+++ b/tests/usfmjsTests/ts_2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tstudio/origin.json
+++ b/tests/usfmjsTests/tstudio/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tstudio/origin.json
+++ b/tests/usfmjsTests/tstudio/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tw_words/origin.json
+++ b/tests/usfmjsTests/tw_words/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tw_words/origin.json
+++ b/tests/usfmjsTests/tw_words/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tw_words_chunk/origin.json
+++ b/tests/usfmjsTests/tw_words_chunk/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tw_words_chunk/origin.json
+++ b/tests/usfmjsTests/tw_words_chunk/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/usfmIntroTest/origin.json
+++ b/tests/usfmjsTests/usfmIntroTest/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/usfmIntroTest/origin.json
+++ b/tests/usfmjsTests/usfmIntroTest/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/valid/origin.json
+++ b/tests/usfmjsTests/valid/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/valid/origin.json
+++ b/tests/usfmjsTests/valid/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "content": [
     {
       "type": "book",


### PR DESCRIPTION
This PR includes

- Minor updates in the USJ schema
    - [x] Make the version number there same as that in USJ testsuite samples
    - [x] Set 'marker' field as 'required'
- [x] Keep `ca`, `cp`, `va`, `vp` objects as separate elements in USJ like it is in USFM (https://github.com/usfm-bible/tcdocs/commit/866440e493491504649358bf87d9ea5e5cd6e2c9)
    - [x] The code changes for this is copied to `python/lib/usjproc.py` as well
    - Reasoning behind it
       - They are separate `char` and `para` type markers in USFM, though not so in USX
       - They are sometimes seen to be used in between chapters and verse text, making it hard to tie it properly to a chapter or verse object. In this context, USX also seem to handle them as separate objects
- [x] Version bump for USJ to 0.2.4 in schema, script and testsuite samples, including the following changes:
    - White space handling in previous PR #65 
    - Make 'marker' filed `required` in USJ schema
    - Keep altnumber and pubnumber fileds as separate objects