### PR TITLE
USJ version 3.1

### DIFF
--- a/python/lib/usfmtc/usjproc.py
+++ b/python/lib/usfmtc/usjproc.py
@@ -1,7 +1,19 @@
 
 from usfmtc.xmlutils import ParentElement
 
-def usxtousj(input_usx_elmt):
+SPEC_NAME="USJ"
+VERSION_NUM="3.1"
+
+def usxtousj(input_usx):
+    '''The core function for the process.
+    input: parsed XML element for the whole USX
+    output: dict object as per the JSON schema'''
+    output_json, _ = convert_usx(input_usx)
+    output_json['type'] = SPEC_NAME
+    output_json['version'] = VERSION_NUM
+    return output_json
+
+def convert_usx(input_usx_elmt):
     '''Accepts an XML object of USX and returns a Dict corresponding to it.
     Traverses the children, recursively'''
     key = input_usx_elmt.tag
@@ -51,7 +63,7 @@ def usjtousx(adict, elfactory=None):
     if elfactory is None:
         elfactory = ParentElement       # Needed for adding esid_s. Or use lxml
     root = elfactory('usx')
-    root.set('version', '3.0')
+    root.set('version', '3.1')
     for item in adict['content']:
         convert_usj(item, root, elfactory)
     return root

--- a/python/scripts/usx2usj.py
+++ b/python/scripts/usx2usj.py
@@ -2,7 +2,7 @@ import argparse
 import json
 from lxml import etree
 
-VERSION_NUM = "0.2.3"
+VERSION_NUM = "3.1"
 SPEC_NAME = "USJ" # for Unified Scripture JSON
 
 def convert_usx(input_usx_elmt):

--- a/tests/advanced/custom-attributes/origin.json
+++ b/tests/advanced/custom-attributes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/advanced/default-attributes/origin.json
+++ b/tests/advanced/default-attributes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/advanced/figureInNote/origin.json
+++ b/tests/advanced/figureInNote/origin.json
@@ -1,0 +1,63 @@
+{
+  "type": "USJ",
+  "version": "3.1",
+  "content": [
+    {
+      "type": "book",
+      "marker": "id",
+      "code": "MRK",
+      "content": []
+    },
+    {
+      "type": "chapter",
+      "marker": "c",
+      "number": "1",
+      "sid": "MRK 1"
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "1",
+          "sid": "MRK 1:1"
+        },
+        "the first verse",
+        {
+          "type": "note",
+          "marker": "f",
+          "caller": "-",
+          "content": [
+            {
+              "type": "char",
+              "marker": "fr",
+              "content": [
+                "1 "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "ft",
+              "content": [
+                "note text",
+                {
+                  "type": "figure",
+                  "marker": "fig",
+                  "file": "file.jpg",
+                  "size": "col",
+                  "ref": "GEN 1:1",
+                  "content": [
+                    "caption"
+                  ]
+                },
+                " more text"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/advanced/header/origin.json
+++ b/tests/advanced/header/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/advanced/list/origin.json
+++ b/tests/advanced/list/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/advanced/milestones/origin.json
+++ b/tests/advanced/milestones/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/advanced/nesting/origin.json
+++ b/tests/advanced/nesting/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/advanced/nesting1/origin.json
+++ b/tests/advanced/nesting1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/advanced/periph/origin.json
+++ b/tests/advanced/periph/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/basic/attributes/origin.json
+++ b/tests/basic/attributes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/basic/character/origin.json
+++ b/tests/basic/character/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/basic/cross-refs/origin.json
+++ b/tests/basic/cross-refs/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/basic/footnote/origin.json
+++ b/tests/basic/footnote/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/basic/header/origin.json
+++ b/tests/basic/header/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",
@@ -15,13 +15,6 @@
       "marker": "ide",
       "content": [
         "UTF-8"
-      ]
-    },
-    {
-      "type": "para",
-      "marker": "usfm",
-      "content": [
-        "3.0"
       ]
     },
     {

--- a/tests/basic/minimal/origin.json
+++ b/tests/basic/minimal/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/basic/multiple-chapters/origin.json
+++ b/tests/basic/multiple-chapters/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/basic/multiple-paragraphs/origin.json
+++ b/tests/basic/multiple-paragraphs/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/basic/section/origin.json
+++ b/tests/basic/section/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/biblica/BlankLinesWithFigures/origin.json
+++ b/tests/biblica/BlankLinesWithFigures/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/biblica/CategoriesOnNotes/origin.json
+++ b/tests/biblica/CategoriesOnNotes/origin.json
@@ -1,0 +1,175 @@
+{
+  "type": "USJ",
+  "version": "3.1",
+  "content": [
+    {
+      "type": "book",
+      "marker": "id",
+      "code": "MRK",
+      "content": [
+        "- Test Project"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "rem",
+      "content": [
+        "Note categories"
+      ]
+    },
+    {
+      "type": "chapter",
+      "marker": "c",
+      "number": "1",
+      "sid": "MRK 1"
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "1",
+          "sid": "MRK 1:1"
+        },
+        "Verse one text",
+        {
+          "type": "note",
+          "marker": "f",
+          "caller": "+",
+          "category": "ex st ba",
+          "content": [
+            {
+              "type": "char",
+              "marker": "fr",
+              "content": [
+                "1.1 "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "fq",
+              "content": [
+                "Footnote text "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "ft",
+              "content": [
+                {
+                  "type": "char",
+                  "marker": "xt",
+                  "content": [
+                    "C.f. ",
+                    {
+                      "type": "ref",
+                      "loc": "MRK 1:4",
+                      "content": [
+                        "Mark 1:4"
+                      ]
+                    },
+                    " and ",
+                    {
+                      "type": "ref",
+                      "loc": "MAT 4:3",
+                      "content": [
+                        "Matt. 4:3"
+                      ]
+                    },
+                    "."
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "2",
+          "sid": "MRK 1:2"
+        },
+        "Verse two text ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "3",
+          "sid": "MRK 1:3"
+        },
+        "Verse three text. ",
+        {
+          "type": "note",
+          "marker": "fe",
+          "caller": "+",
+          "category": "ex",
+          "content": [
+            {
+              "type": "char",
+              "marker": "fr",
+              "content": [
+                "1:3 "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "fq",
+              "content": [
+                "End note text."
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "ft",
+              "content": []
+            }
+          ]
+        },
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "4",
+          "sid": "MRK 1:4"
+        },
+        "Verse four text.",
+        {
+          "type": "note",
+          "marker": "x",
+          "caller": "-",
+          "category": "ex st",
+          "content": [
+            {
+              "type": "char",
+              "marker": "xo",
+              "content": [
+                "1:4 "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "xta",
+              "content": [
+                "See "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "xt",
+              "content": [
+                {
+                  "type": "ref",
+                  "loc": "JHN 5:8",
+                  "content": [
+                    "John 5:8"
+                  ]
+                },
+                "."
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/biblica/CrossRefWithPipe/origin.json
+++ b/tests/biblica/CrossRefWithPipe/origin.json
@@ -1,0 +1,89 @@
+{
+  "type": "USJ",
+  "version": "3.1",
+  "content": [
+    {
+      "type": "book",
+      "marker": "id",
+      "code": "GEN",
+      "content": []
+    },
+    {
+      "type": "chapter",
+      "marker": "c",
+      "number": "2",
+      "sid": "GEN 2"
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "5",
+          "sid": "GEN 2:5"
+        },
+        "Now no shrub had yet appeared on the earth",
+        {
+          "type": "note",
+          "marker": "f",
+          "caller": "+",
+          "content": [
+            {
+              "type": "char",
+              "marker": "fr",
+              "content": [
+                "2:5 "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "ft",
+              "content": [
+                "Or "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "fqa",
+              "content": [
+                "land"
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "ft",
+              "content": [
+                "; also in ",
+                {
+                  "type": "char",
+                  "marker": "xt",
+                  "href": "GEN 2:6",
+                  "content": [
+                    {
+                      "type": "ref",
+                      "loc": "GEN 2:6",
+                      "content": [
+                        "verse 6"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        " and no plant had yet sprung up, for the ",
+        {
+          "type": "char",
+          "marker": "nd",
+          "content": [
+            "Lord"
+          ]
+        },
+        " God had not sent rain on the earth and there was no one to work the ground, "
+      ]
+    }
+  ]
+}

--- a/tests/biblica/PublishingVersesWithFormatting/origin.json
+++ b/tests/biblica/PublishingVersesWithFormatting/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/introductions/bad/test1/origin.json
+++ b/tests/introductions/bad/test1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/mandatory/emptyV/origin.json
+++ b/tests/mandatory/emptyV/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/mandatory/id/origin.json
+++ b/tests/mandatory/id/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "chapter",

--- a/tests/mandatory/minimum/origin.json
+++ b/tests/mandatory/minimum/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/mandatory/v/origin.json
+++ b/tests/mandatory/v/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/CharStyleClosedAndReopened/origin.json
+++ b/tests/paratextTests/CharStyleClosedAndReopened/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/CharStyleCrossesFootnote/origin.json
+++ b/tests/paratextTests/CharStyleCrossesFootnote/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/CharStyleCrossesVerseNumber/origin.json
+++ b/tests/paratextTests/CharStyleCrossesVerseNumber/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/CharStyleNotClosed/origin.json
+++ b/tests/paratextTests/CharStyleNotClosed/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/CrossReferencesInsideCharacterMarker/origin.json
+++ b/tests/paratextTests/CrossReferencesInsideCharacterMarker/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/CustomAttributesAreValid/origin.json
+++ b/tests/paratextTests/CustomAttributesAreValid/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/EmptyFigure/origin.json
+++ b/tests/paratextTests/EmptyFigure/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",
@@ -45,11 +45,10 @@
       "content": [
         "And",
         {
-          "type": "char",
+          "type": "figure",
           "marker": "fig",
-          "content": [
-            "| src=\"figure.png\""
-          ]
+          "file": "figure.png",
+          "content": []
         },
         " and some more text"
       ]
@@ -60,7 +59,7 @@
       "content": [
         "And",
         {
-          "type": "char",
+          "type": "figure",
           "marker": "fig",
           "content": []
         },

--- a/tests/paratextTests/EmptyMarkers/origin.json
+++ b/tests/paratextTests/EmptyMarkers/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/FigureAttributesAreValid/origin.json
+++ b/tests/paratextTests/FigureAttributesAreValid/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/FigureNotClosed/origin.json
+++ b/tests/paratextTests/FigureNotClosed/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/FootnoteConsistencyCheck/origin.json
+++ b/tests/paratextTests/FootnoteConsistencyCheck/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",
@@ -70,7 +70,7 @@
         {
           "type": "note",
           "marker": "f",
-          "caller": "",
+          "caller": "-",
           "content": [
             {
               "type": "char",

--- a/tests/paratextTests/FootnoteNotClosed/origin.json
+++ b/tests/paratextTests/FootnoteNotClosed/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/FootnoteWithWrongSpacingAroundCaller/origin.json
+++ b/tests/paratextTests/FootnoteWithWrongSpacingAroundCaller/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/GlossaryCitationFormContainingWordMedialPunctuation_Pass/origin.json
+++ b/tests/paratextTests/GlossaryCitationFormContainingWordMedialPunctuation_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/GlossaryCitationFormContainsComma_Pass/origin.json
+++ b/tests/paratextTests/GlossaryCitationFormContainsComma_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/GlossaryCitationFormContainsNonWordformingPunctuation/origin.json
+++ b/tests/paratextTests/GlossaryCitationFormContainsNonWordformingPunctuation/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/GlossaryCitationFormEndsInPunctuation/origin.json
+++ b/tests/paratextTests/GlossaryCitationFormEndsInPunctuation/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/GlossaryCitationFormEndsInSpace/origin.json
+++ b/tests/paratextTests/GlossaryCitationFormEndsInSpace/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/GlossaryCitationFormEndsWithParentheses_Pass/origin.json
+++ b/tests/paratextTests/GlossaryCitationFormEndsWithParentheses_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/GlossaryCitationFormMultipleWords_Pass/origin.json
+++ b/tests/paratextTests/GlossaryCitationFormMultipleWords_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/GlossaryCitationForm_Pass/origin.json
+++ b/tests/paratextTests/GlossaryCitationForm_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/GlossaryNoKeywordErrors/origin.json
+++ b/tests/paratextTests/GlossaryNoKeywordErrors/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/IdMarkerInMiddleOfBook/origin.json
+++ b/tests/paratextTests/IdMarkerInMiddleOfBook/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/IgnoreKeywordErrorsOutsideOfGlossary/origin.json
+++ b/tests/paratextTests/IgnoreKeywordErrorsOutsideOfGlossary/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/InvalidAttributeValuesReported/origin.json
+++ b/tests/paratextTests/InvalidAttributeValuesReported/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/InvalidAttributes/origin.json
+++ b/tests/paratextTests/InvalidAttributes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/InvalidFigureAttributesReported/origin.json
+++ b/tests/paratextTests/InvalidFigureAttributesReported/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/InvalidMarker/origin.json
+++ b/tests/paratextTests/InvalidMarker/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/InvalidMilestone_EndWithoutStart/origin.json
+++ b/tests/paratextTests/InvalidMilestone_EndWithoutStart/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/InvalidMilestone_IdsDontMatch/origin.json
+++ b/tests/paratextTests/InvalidMilestone_IdsDontMatch/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/InvalidMilestone_MissingEnd/origin.json
+++ b/tests/paratextTests/InvalidMilestone_MissingEnd/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/InvalidRubyMarkup/origin.json
+++ b/tests/paratextTests/InvalidRubyMarkup/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",
@@ -94,8 +94,9 @@
         {
           "type": "char",
           "marker": "rb",
+          "gloss": "g",
           "content": [
-            "BB|"
+            "BB"
           ]
         }
       ]

--- a/tests/paratextTests/LinkAttributesAreValid/origin.json
+++ b/tests/paratextTests/LinkAttributesAreValid/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/MajorTitleRequired/origin.json
+++ b/tests/paratextTests/MajorTitleRequired/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/MarkersMissingSpace/origin.json
+++ b/tests/paratextTests/MarkersMissingSpace/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/MissingColumnInTable/origin.json
+++ b/tests/paratextTests/MissingColumnInTable/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/MissingIdAndChapterMarkers/origin.json
+++ b/tests/paratextTests/MissingIdAndChapterMarkers/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "para",

--- a/tests/paratextTests/MissingIdMarker/origin.json
+++ b/tests/paratextTests/MissingIdMarker/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "chapter",

--- a/tests/paratextTests/MissingRequiredAttributesReported/origin.json
+++ b/tests/paratextTests/MissingRequiredAttributesReported/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",
@@ -31,18 +31,13 @@
           "number": "1",
           "sid": "GEN 1:1"
         },
-        "verse text "
-      ]
-    },
-    {
-      "type": "para",
-      "marker": "xyz",
-      "content": [
-        "text",
+        "verse text ",
         {
-          "type": "unmatched",
-          "marker": "xyz*",
-          "content": []
+          "type": "char",
+          "marker": "rb",
+          "content": [
+            "text"
+          ]
         }
       ]
     }

--- a/tests/paratextTests/NbMarkerInCorrectPlace/origin.json
+++ b/tests/paratextTests/NbMarkerInCorrectPlace/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/NbMarkerInWrongPlace/origin.json
+++ b/tests/paratextTests/NbMarkerInWrongPlace/origin.json
@@ -1,0 +1,82 @@
+{
+  "type": "USJ",
+  "version": "3.1",
+  "content": [
+    {
+      "type": "book",
+      "marker": "id",
+      "code": "GEN",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "ib",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "ip",
+      "content": [
+        "Hi mom."
+      ]
+    },
+    {
+      "type": "chapter",
+      "marker": "c",
+      "number": "1",
+      "sid": "GEN 1"
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "1",
+          "sid": "GEN 1:1"
+        },
+        "Hi Bob."
+      ]
+    },
+    {
+      "type": "chapter",
+      "marker": "c",
+      "number": "2",
+      "sid": "GEN 2"
+    },
+    {
+      "type": "para",
+      "marker": "s",
+      "content": [
+        "Monkey"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "1",
+          "sid": "GEN 2:1"
+        },
+        "Soup is good!"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "nb",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "2",
+          "sid": "GEN 2:2"
+        },
+        "So is the bread"
+      ]
+    }
+  ]
+}

--- a/tests/paratextTests/NestingInCrossReferences/origin.json
+++ b/tests/paratextTests/NestingInCrossReferences/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/NestingInFootnote/origin.json
+++ b/tests/paratextTests/NestingInFootnote/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/NestingUnclosed/origin.json
+++ b/tests/paratextTests/NestingUnclosed/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/NoErrorsEmptyBook/origin.json
+++ b/tests/paratextTests/NoErrorsEmptyBook/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/NoErrorsNesting/origin.json
+++ b/tests/paratextTests/NoErrorsNesting/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/NoErrorsPartiallyEmptyBook/origin.json
+++ b/tests/paratextTests/NoErrorsPartiallyEmptyBook/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/NoErrorsShort/origin.json
+++ b/tests/paratextTests/NoErrorsShort/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/NoErrosLong/origin.json
+++ b/tests/paratextTests/NoErrosLong/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/OnlyChapterAndVerseMarkers/origin.json
+++ b/tests/paratextTests/OnlyChapterAndVerseMarkers/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/UnmatchedSidebarEnd/origin.json
+++ b/tests/paratextTests/UnmatchedSidebarEnd/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/UnmatchedSidebarStart/origin.json
+++ b/tests/paratextTests/UnmatchedSidebarStart/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/Usfm30Usage/origin.json
+++ b/tests/paratextTests/Usfm30Usage/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",
@@ -46,30 +46,16 @@
           "number": "1",
           "sid": "GEN 1:1"
         },
-        "verse text "
-      ]
-    },
-    {
-      "type": "para",
-      "marker": "qts",
-      "content": [
-        "|speaker",
+        "verse text ",
         {
-          "type": "unmatched",
-          "marker": "*",
-          "content": []
+          "type": "ms",
+          "marker": "qt-s",
+          "who": "speaker"
         },
-        " quoted text "
-      ]
-    },
-    {
-      "type": "para",
-      "marker": "qte",
-      "content": [
+        " quoted text ",
         {
-          "type": "unmatched",
-          "marker": "*",
-          "content": []
+          "type": "ms",
+          "marker": "qt-e"
         },
         {
           "type": "verse",

--- a/tests/paratextTests/ValidMilestones/origin.json
+++ b/tests/paratextTests/ValidMilestones/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/ValidRubyMarkup/origin.json
+++ b/tests/paratextTests/ValidRubyMarkup/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerKeywordContainsComma_Pass/origin.json
+++ b/tests/paratextTests/WordlistMarkerKeywordContainsComma_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerKeywordContainsNonWordformingPunctuation/origin.json
+++ b/tests/paratextTests/WordlistMarkerKeywordContainsNonWordformingPunctuation/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerKeywordEndsInPunctuation/origin.json
+++ b/tests/paratextTests/WordlistMarkerKeywordEndsInPunctuation/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerKeywordEndsInSpace/origin.json
+++ b/tests/paratextTests/WordlistMarkerKeywordEndsInSpace/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerKeywordEndsInSpaceGlossaryEntryPresent_Pass/origin.json
+++ b/tests/paratextTests/WordlistMarkerKeywordEndsInSpaceGlossaryEntryPresent_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerKeywordWithParentheses_Pass/origin.json
+++ b/tests/paratextTests/WordlistMarkerKeywordWithParentheses_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerMissingFromGlossaryCitationForms/origin.json
+++ b/tests/paratextTests/WordlistMarkerMissingFromGlossaryCitationForms/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerNestedProperNounWithKeyword_Pass/origin.json
+++ b/tests/paratextTests/WordlistMarkerNestedProperNounWithKeyword_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerNestedProperNoun_Pass/origin.json
+++ b/tests/paratextTests/WordlistMarkerNestedProperNoun_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerNestedShouldNotIncludeKeyword/origin.json
+++ b/tests/paratextTests/WordlistMarkerNestedShouldNotIncludeKeyword/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerNestedTwoProperNouns_Pass/origin.json
+++ b/tests/paratextTests/WordlistMarkerNestedTwoProperNouns_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerTextContainsNonWordformingPunctuation/origin.json
+++ b/tests/paratextTests/WordlistMarkerTextContainsNonWordformingPunctuation/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerTextEndsInPunctuation/origin.json
+++ b/tests/paratextTests/WordlistMarkerTextEndsInPunctuation/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerTextEndsInSpaceAndMissingFromGlossary/origin.json
+++ b/tests/paratextTests/WordlistMarkerTextEndsInSpaceAndMissingFromGlossary/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerTextEndsInSpaceGlossaryEntryPresent_Pass/origin.json
+++ b/tests/paratextTests/WordlistMarkerTextEndsInSpaceGlossaryEntryPresent_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerTextEndsInSpaceWithGlossary/origin.json
+++ b/tests/paratextTests/WordlistMarkerTextEndsInSpaceWithGlossary/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerTextEndsInSpaceWithoutGlossary/origin.json
+++ b/tests/paratextTests/WordlistMarkerTextEndsInSpaceWithoutGlossary/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/paratextTests/WordlistMarkerWithKeyword_Pass/origin.json
+++ b/tests/paratextTests/WordlistMarkerWithKeyword_Pass/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/WEB1/origin.json
+++ b/tests/samples-from-wild/WEB1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/WEB2/origin.json
+++ b/tests/samples-from-wild/WEB2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/WEB3/origin.json
+++ b/tests/samples-from-wild/WEB3/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/brenton1/origin.json
+++ b/tests/samples-from-wild/brenton1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/brenton2/origin.json
+++ b/tests/samples-from-wild/brenton2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/chinese1/origin.json
+++ b/tests/samples-from-wild/chinese1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/chinese2/origin.json
+++ b/tests/samples-from-wild/chinese2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/chinese3/origin.json
+++ b/tests/samples-from-wild/chinese3/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/doo43-1/origin.json
+++ b/tests/samples-from-wild/doo43-1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/doo43-3/origin.json
+++ b/tests/samples-from-wild/doo43-3/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/doo43-4/origin.json
+++ b/tests/samples-from-wild/doo43-4/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/hindi-IRV1/origin.json
+++ b/tests/samples-from-wild/hindi-IRV1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/hindi-IRV2/origin.json
+++ b/tests/samples-from-wild/hindi-IRV2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/rv2/origin.json
+++ b/tests/samples-from-wild/rv2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/rv3/origin.json
+++ b/tests/samples-from-wild/rv3/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/t4t1/origin.json
+++ b/tests/samples-from-wild/t4t1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/t4t3/origin.json
+++ b/tests/samples-from-wild/t4t3/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/ta2il-IRV1/origin.json
+++ b/tests/samples-from-wild/ta2il-IRV1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/samples-from-wild/tamil-IRV1/origin.json
+++ b/tests/samples-from-wild/tamil-IRV1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/attributes/origin.json
+++ b/tests/specExamples/attributes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/chapter-verse/origin.json
+++ b/tests/specExamples/chapter-verse/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/character/origin.json
+++ b/tests/specExamples/character/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/cross-ref/origin.json
+++ b/tests/specExamples/cross-ref/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",
@@ -126,7 +126,7 @@
         {
           "type": "char",
           "marker": "xt",
-          "link-href": "GEN 2:1",
+          "href": "GEN 2:1",
           "content": [
             "1"
           ]
@@ -135,7 +135,7 @@
         {
           "type": "char",
           "marker": "xt",
-          "link-href": "GEN 2:8",
+          "href": "GEN 2:8",
           "content": [
             "8"
           ]
@@ -144,7 +144,7 @@
         {
           "type": "char",
           "marker": "xt",
-          "link-href": "GEN 2:18",
+          "href": "GEN 2:18",
           "content": [
             "18"
           ]
@@ -153,7 +153,7 @@
         {
           "type": "char",
           "marker": "xt",
-          "link-href": "GEN 2:21",
+          "href": "GEN 2:21",
           "content": [
             "21"
           ]

--- a/tests/specExamples/extended/bookIntroductions1/origin.json
+++ b/tests/specExamples/extended/bookIntroductions1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/extended/bookIntroductions2/origin.json
+++ b/tests/specExamples/extended/bookIntroductions2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/extended/contentCatogories1/origin.json
+++ b/tests/specExamples/extended/contentCatogories1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/extended/contentCatogories2/origin.json
+++ b/tests/specExamples/extended/contentCatogories2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/extended/footnotes/origin.json
+++ b/tests/specExamples/extended/footnotes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/extended/sectionIntroductions/origin.json
+++ b/tests/specExamples/extended/sectionIntroductions/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/extended/sidebars/origin.json
+++ b/tests/specExamples/extended/sidebars/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/footnote/origin.json
+++ b/tests/specExamples/footnote/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",
@@ -164,14 +164,14 @@
               "type": "char",
               "marker": "fqa",
               "content": [
-                "“Whoever is thirsty should come to me and drink. "
-              ]
-            },
-            {
-              "type": "char",
-              "marker": "fv",
-              "content": [
-                "38"
+                "“Whoever is thirsty should come to me and drink. ",
+                {
+                  "type": "char",
+                  "marker": "fv",
+                  "content": [
+                    "38"
+                  ]
+                }
               ]
             },
             {

--- a/tests/specExamples/identification/origin.json
+++ b/tests/specExamples/identification/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",
@@ -8,13 +8,6 @@
       "code": "MAT",
       "content": [
         "41MATGNT92.SFM, Good News Translation, June 2003"
-      ]
-    },
-    {
-      "type": "para",
-      "marker": "usfm",
-      "content": [
-        "3.0"
       ]
     },
     {

--- a/tests/specExamples/introduction1/origin.json
+++ b/tests/specExamples/introduction1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",
@@ -8,13 +8,6 @@
       "code": "MAT",
       "content": [
         "41MATGNT92.SFM, Good News Translation, June 2003"
-      ]
-    },
-    {
-      "type": "para",
-      "marker": "usfm",
-      "content": [
-        "3.0"
       ]
     },
     {

--- a/tests/specExamples/introduction2/origin.json
+++ b/tests/specExamples/introduction2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/introduction3/origin.json
+++ b/tests/specExamples/introduction3/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/list/origin.json
+++ b/tests/specExamples/list/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",
@@ -8,13 +8,6 @@
       "code": "MAT",
       "content": [
         "41MATGNT92.SFM, Good News Translation, June 2003"
-      ]
-    },
-    {
-      "type": "para",
-      "marker": "usfm",
-      "content": [
-        "3.0"
       ]
     },
     {

--- a/tests/specExamples/milestone/origin.json
+++ b/tests/specExamples/milestone/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/specExamples/paragraph/origin.json
+++ b/tests/specExamples/paragraph/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",
@@ -8,13 +8,6 @@
       "code": "MAT",
       "content": [
         "41MATGNT92.SFM, Good News Translation, June 2003"
-      ]
-    },
-    {
-      "type": "para",
-      "marker": "usfm",
-      "content": [
-        "3.0"
       ]
     },
     {

--- a/tests/specExamples/poetry/origin.json
+++ b/tests/specExamples/poetry/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",
@@ -8,13 +8,6 @@
       "code": "MAT",
       "content": [
         "41MATGNT92.SFM, Good News Translation, June 2003"
-      ]
-    },
-    {
-      "type": "para",
-      "marker": "usfm",
-      "content": [
-        "3.0"
       ]
     },
     {

--- a/tests/specExamples/table/origin.json
+++ b/tests/specExamples/table/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",
@@ -8,13 +8,6 @@
       "code": "MAT",
       "content": [
         "41MATGNT92.SFM, Good News Translation, June 2003"
-      ]
-    },
-    {
-      "type": "para",
-      "marker": "usfm",
-      "content": [
-        "3.0"
       ]
     },
     {
@@ -242,7 +235,7 @@
               "marker": "tcr3",
               "align": "end",
               "content": [
-                "Shelumiel son of Zurishaddai"
+                "Shelumiel son of Zurishaddai\n        "
               ]
             }
           ]

--- a/tests/specExamples/titles/origin.json
+++ b/tests/specExamples/titles/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",
@@ -8,13 +8,6 @@
       "code": "MAT",
       "content": [
         "41MATGNT92.SFM, Good News Translation, June 2003"
-      ]
-    },
-    {
-      "type": "para",
-      "marker": "usfm",
-      "content": [
-        "3.0"
       ]
     },
     {

--- a/tests/special-cases/IRV1/origin.json
+++ b/tests/special-cases/IRV1/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/IRV2/origin.json
+++ b/tests/special-cases/IRV2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/IRV3/origin.json
+++ b/tests/special-cases/IRV3/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/IRV4/origin.json
+++ b/tests/special-cases/IRV4/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/IRV5/origin.json
+++ b/tests/special-cases/IRV5/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/IRV6/origin.json
+++ b/tests/special-cases/IRV6/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/IRV7/origin.json
+++ b/tests/special-cases/IRV7/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/IRV8/origin.json
+++ b/tests/special-cases/IRV8/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/IRV9/origin.json
+++ b/tests/special-cases/IRV9/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-attributes/origin.json
+++ b/tests/special-cases/empty-attributes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-attributes2/origin.json
+++ b/tests/special-cases/empty-attributes2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-attributes3/origin.json
+++ b/tests/special-cases/empty-attributes3/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-attributes4/origin.json
+++ b/tests/special-cases/empty-attributes4/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-attributes5/origin.json
+++ b/tests/special-cases/empty-attributes5/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-book/origin.json
+++ b/tests/special-cases/empty-book/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-c/origin.json
+++ b/tests/special-cases/empty-c/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-li/origin.json
+++ b/tests/special-cases/empty-li/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-lines/origin.json
+++ b/tests/special-cases/empty-lines/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-para/origin.json
+++ b/tests/special-cases/empty-para/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/empty-para2/origin.json
+++ b/tests/special-cases/empty-para2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/figure_with_quotes_in_desc/origin.json
+++ b/tests/special-cases/figure_with_quotes_in_desc/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/id-in-text/origin.json
+++ b/tests/special-cases/id-in-text/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/nbsp/origin.json
+++ b/tests/special-cases/nbsp/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/nested-notes/origin.json
+++ b/tests/special-cases/nested-notes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/nesting/origin.json
+++ b/tests/special-cases/nesting/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/newline-attributes/origin.json
+++ b/tests/special-cases/newline-attributes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/notes/origin.json
+++ b/tests/special-cases/notes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/notes2/origin.json
+++ b/tests/special-cases/notes2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/pi/origin.json
+++ b/tests/special-cases/pi/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/punct-at-break/origin.json
+++ b/tests/special-cases/punct-at-break/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/qa/origin.json
+++ b/tests/special-cases/qa/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/special-cases/sp/origin.json
+++ b/tests/special-cases/sp/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/1ch_verse_span/origin.json
+++ b/tests/usfmjsTests/1ch_verse_span/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/57-TIT.greek.oldformat/origin.json
+++ b/tests/usfmjsTests/57-TIT.greek.oldformat/origin.json
@@ -1,0 +1,7510 @@
+{
+  "type": "USJ",
+  "version": "3.1",
+  "content": [
+    {
+      "type": "book",
+      "marker": "id",
+      "code": "TIT",
+      "content": [
+        "Titus"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ide",
+      "content": [
+        "UTF-8"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "h",
+      "content": [
+        "Titus"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "toc1",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "toc2",
+      "content": [
+        "Titus"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "toc3",
+      "content": [
+        "Tit"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "mt",
+      "content": [
+        "Titus"
+      ]
+    },
+    {
+      "type": "chapter",
+      "marker": "c",
+      "number": "1",
+      "sid": "TIT 1"
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "1",
+          "sid": "TIT 1:1"
+        }
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "Παῦλος",
+          "strong": "G39720",
+          "x-morph": "Gr,N,,,,,NMS,",
+          "x-tw": "rc://*/tw/dict/bible/names/paul",
+          "content": [
+            "Παῦλος"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "δοῦλος",
+          "strong": "G14010",
+          "x-morph": "Gr,N,,,,,NMS,",
+          "x-tw": "rc://*/tw/dict/bible/other/servant",
+          "content": [
+            "δοῦλος"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "θεός",
+          "strong": "G23160",
+          "x-morph": "Gr,N,,,,,GMS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/god",
+          "content": [
+            "Θεοῦ"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀπόστολος",
+          "strong": "G06520",
+          "x-morph": "Gr,N,,,,,NMS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/apostle",
+          "content": [
+            "ἀπόστολος"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "δέ",
+          "strong": "G11610",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "δὲ"
+          ]
+        },
+        " \\k-s| x-tw=\"rc:",
+        {
+          "type": "optbreak"
+        },
+        "*/tw/dict/bible/kt/jesus\"\n",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "Ἰησοῦς",
+          "strong": "G24240",
+          "x-morph": "Gr,N,,,,,GMS,",
+          "content": [
+            "Ἰησοῦ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "χριστός",
+          "strong": "G55470",
+          "x-morph": "Gr,N,,,,,GMS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/christ",
+          "content": [
+            "Χριστοῦ"
+          ]
+        },
+        {
+          "type": "ms",
+          "marker": "k-e"
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "κατά",
+          "strong": "G25960",
+          "x-morph": "Gr,P,,,,,A,,,",
+          "content": [
+            "κατὰ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πίστις",
+          "strong": "G41020",
+          "x-morph": "Gr,N,,,,,AFS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/faith",
+          "content": [
+            "πίστιν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐκλεκτός",
+          "strong": "G15880",
+          "x-morph": "Gr,NS,,,,GMP,",
+          "x-tw": "rc://*/tw/dict/bible/kt/elect",
+          "content": [
+            "ἐκλεκτῶν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "θεός",
+          "strong": "G23160",
+          "x-morph": "Gr,N,,,,,GMS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/god",
+          "content": [
+            "Θεοῦ"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καί",
+          "strong": "G25320",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "καὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐπίγνωσις",
+          "strong": "G19220",
+          "x-morph": "Gr,N,,,,,AFS,",
+          "x-tw": "rc://*/tw/dict/bible/other/know",
+          "content": [
+            "ἐπίγνωσιν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀλήθεια",
+          "strong": "G02250",
+          "x-morph": "Gr,N,,,,,GFS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/true",
+          "content": [
+            "ἀληθείας"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,RR,,,,GFS,",
+          "content": [
+            "τῆς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "κατά",
+          "strong": "G25960",
+          "x-morph": "Gr,P,,,,,A,,,",
+          "content": [
+            "κατ’"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "εὐσέβεια",
+          "strong": "G21500",
+          "x-morph": "Gr,N,,,,,AFS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/godly",
+          "content": [
+            "εὐσέβειαν"
+          ]
+        },
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "2",
+          "sid": "TIT 1:2"
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐπί",
+          "strong": "G19090",
+          "x-morph": "Gr,P,,,,,D,,,",
+          "content": [
+            "ἐπ’"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐλπίς",
+          "strong": "G16800",
+          "x-morph": "Gr,N,,,,,DFS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/hope",
+          "content": [
+            "ἐλπίδι"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ζωή",
+          "strong": "G22220",
+          "x-morph": "Gr,N,,,,,GFS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/life",
+          "content": [
+            "ζωῆς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "αἰώνιος",
+          "strong": "G01660",
+          "x-morph": "Gr,AA,,,,GFS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/eternity",
+          "content": [
+            "αἰωνίου"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὅς",
+          "strong": "G37390",
+          "x-morph": "Gr,RR,,,,AFS,",
+          "content": [
+            "ἣν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐπαγγέλλω",
+          "strong": "G18610",
+          "x-morph": "Gr,V,IAM3,,S,",
+          "x-tw": "rc://*/tw/dict/bible/kt/promise",
+          "content": [
+            "ἐπηγγείλατο"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,NMS,",
+          "content": [
+            "ὁ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀψευδής",
+          "strong": "G08930",
+          "x-morph": "Gr,AA,,,,NMS,",
+          "content": [
+            "ἀψευδὴς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "θεός",
+          "strong": "G23160",
+          "x-morph": "Gr,N,,,,,NMS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/god",
+          "content": [
+            "Θεὸς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πρό",
+          "strong": "G42530",
+          "x-morph": "Gr,P,,,,,G,,,",
+          "content": [
+            "πρὸ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "χρόνος",
+          "strong": "G55500",
+          "x-morph": "Gr,N,,,,,GMP,",
+          "x-tw": "rc://*/tw/dict/bible/other/time",
+          "content": [
+            "χρόνων"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "αἰώνιος",
+          "strong": "G01660",
+          "x-morph": "Gr,AA,,,,GMP,",
+          "x-tw": "rc://*/tw/dict/bible/kt/eternity",
+          "content": [
+            "αἰωνίων"
+          ]
+        },
+        ", ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "3",
+          "sid": "TIT 1:3"
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "φανερόω",
+          "strong": "G53190",
+          "x-morph": "Gr,V,IAA3,,S,",
+          "x-tw": "rc://*/tw/dict/bible/kt/reveal",
+          "content": [
+            "ἐφανέρωσεν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "δέ",
+          "strong": "G11610",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "δὲ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καιρός",
+          "strong": "G25400",
+          "x-morph": "Gr,N,,,,,DMP,",
+          "x-tw": "rc://*/tw/dict/bible/other/time",
+          "content": [
+            "καιροῖς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἴδιος",
+          "strong": "G23980",
+          "x-morph": "Gr,EF,,,,DMP,",
+          "content": [
+            "ἰδίοις"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,AMS,",
+          "content": [
+            "τὸν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "λόγος",
+          "strong": "G30560",
+          "x-morph": "Gr,N,,,,,AMS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/wordofgod",
+          "content": [
+            "λόγον"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "αὐτός",
+          "strong": "G08460",
+          "x-morph": "Gr,RP,,,3GMS,",
+          "content": [
+            "αὐτοῦ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐν",
+          "strong": "G17220",
+          "x-morph": "Gr,P,,,,,D,,,",
+          "content": [
+            "ἐν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "κήρυγμα",
+          "strong": "G27820",
+          "x-morph": "Gr,N,,,,,DNS,",
+          "x-tw": "rc://*/tw/dict/bible/other/preach",
+          "content": [
+            "κηρύγματι"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὅς",
+          "strong": "G37390",
+          "x-morph": "Gr,RR,,,,ANS,",
+          "content": [
+            "ὃ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πιστεύω",
+          "strong": "G41000",
+          "x-morph": "Gr,V,IAP1,,S,",
+          "x-tw": "rc://*/tw/dict/bible/kt/trust",
+          "content": [
+            "ἐπιστεύθην"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐγώ",
+          "strong": "G14730",
+          "x-morph": "Gr,RP,,,1N,S,",
+          "content": [
+            "ἐγὼ"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "κατά",
+          "strong": "G25960",
+          "x-morph": "Gr,P,,,,,A,,,",
+          "content": [
+            "κατ’"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐπιταγή",
+          "strong": "G20030",
+          "x-morph": "Gr,N,,,,,AFS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/command",
+          "content": [
+            "ἐπιταγὴν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,GMS,",
+          "content": [
+            "τοῦ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "σωτήρ",
+          "strong": "G49900",
+          "x-morph": "Gr,N,,,,,GMS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/savior",
+          "content": [
+            "Σωτῆρος"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐγώ",
+          "strong": "G14730",
+          "x-morph": "Gr,RP,,,1G,P,",
+          "content": [
+            "ἡμῶν"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "θεός",
+          "strong": "G23160",
+          "x-morph": "Gr,N,,,,,GMS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/god",
+          "content": [
+            "Θεοῦ"
+          ]
+        },
+        "; ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "4",
+          "sid": "TIT 1:4"
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "Τίτος",
+          "strong": "G51030",
+          "x-morph": "Gr,N,,,,,DMS,",
+          "x-tw": "rc://*/tw/dict/bible/names/titus",
+          "content": [
+            "Τίτῳ"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "γνήσιος",
+          "strong": "G11030",
+          "x-morph": "Gr,AA,,,,DNS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/true",
+          "content": [
+            "γνησίῳ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "τέκνον",
+          "strong": "G50430",
+          "x-morph": "Gr,N,,,,,DNS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/son",
+          "content": [
+            "τέκνῳ"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "κατά",
+          "strong": "G25960",
+          "x-morph": "Gr,P,,,,,A,,,",
+          "content": [
+            "κατὰ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "κοινός",
+          "strong": "G28390",
+          "x-morph": "Gr,AA,,,,AFS,",
+          "content": [
+            "κοινὴν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πίστις",
+          "strong": "G41020",
+          "x-morph": "Gr,N,,,,,AFS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/faith",
+          "content": [
+            "πίστιν"
+          ]
+        },
+        ": ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "χάρις",
+          "strong": "G54850",
+          "x-morph": "Gr,N,,,,,NFS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/grace",
+          "content": [
+            "χάρις"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καί",
+          "strong": "G25320",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "καὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "εἰρήνη",
+          "strong": "G15150",
+          "x-morph": "Gr,N,,,,,NFS,",
+          "x-tw": "rc://*/tw/dict/bible/other/peace",
+          "content": [
+            "εἰρήνη"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀπό",
+          "strong": "G05750",
+          "x-morph": "Gr,P,,,,,G,,,",
+          "content": [
+            "ἀπὸ"
+          ]
+        },
+        " \\k-s| x-tw=\"rc:",
+        {
+          "type": "optbreak"
+        },
+        "*/tw/dict/bible/kt/godthefather\"\n",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "θεός",
+          "strong": "G23160",
+          "x-morph": "Gr,N,,,,,GMS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/god",
+          "content": [
+            "Θεοῦ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πατήρ",
+          "strong": "G39620",
+          "x-morph": "Gr,N,,,,,GMS,",
+          "content": [
+            "Πατρὸς"
+          ]
+        },
+        {
+          "type": "ms",
+          "marker": "k-e"
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καί",
+          "strong": "G25320",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "καὶ"
+          ]
+        },
+        " \\k-s| x-tw=\"rc:",
+        {
+          "type": "optbreak"
+        },
+        "*/tw/dict/bible/kt/jesus\"\n",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "χριστός",
+          "strong": "G55470",
+          "x-morph": "Gr,N,,,,,GMS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/christ",
+          "content": [
+            "Χριστοῦ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "Ἰησοῦς",
+          "strong": "G24240",
+          "x-morph": "Gr,N,,,,,GMS,",
+          "content": [
+            "Ἰησοῦ"
+          ]
+        },
+        {
+          "type": "ms",
+          "marker": "k-e"
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,GMS,",
+          "content": [
+            "τοῦ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "σωτήρ",
+          "strong": "G49900",
+          "x-morph": "Gr,N,,,,,GMS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/savior",
+          "content": [
+            "Σωτῆρος"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐγώ",
+          "strong": "G14730",
+          "x-morph": "Gr,RP,,,1G,P,",
+          "content": [
+            "ἡμῶν"
+          ]
+        },
+        ". ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "5",
+          "sid": "TIT 1:5"
+        }
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "οὗτος",
+          "strong": "G37780",
+          "x-morph": "Gr,RD,,,,GNS,",
+          "content": [
+            "τούτου"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "χάριν",
+          "strong": "G54840",
+          "x-morph": "Gr,PI,,,,G,,,",
+          "content": [
+            "χάριν"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀπολίπω",
+          "strong": "G06200",
+          "x-morph": "Gr,V,IAA1,,S,",
+          "content": [
+            "ἀπέλιπόν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "σύ",
+          "strong": "G47710",
+          "x-morph": "Gr,RP,,,2A,S,",
+          "content": [
+            "σε"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐν",
+          "strong": "G17220",
+          "x-morph": "Gr,P,,,,,D,,,",
+          "content": [
+            "ἐν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "Κρήτη",
+          "strong": "G29140",
+          "x-morph": "Gr,N,,,,,DFS,",
+          "x-tw": "rc://*/tw/dict/bible/names/crete",
+          "content": [
+            "Κρήτῃ"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἵνα",
+          "strong": "G24430",
+          "x-morph": "Gr,CS,,,,,,,,",
+          "content": [
+            "ἵνα"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,RD,,,,ANP,",
+          "content": [
+            "τὰ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "λείπω",
+          "strong": "G30070",
+          "x-morph": "Gr,V,PPA,ANP,",
+          "content": [
+            "λείποντα"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐπιδιορθόω",
+          "strong": "G19300",
+          "x-morph": "Gr,V,SAM2,,S,",
+          "content": [
+            "ἐπιδιορθώσῃ"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καί",
+          "strong": "G25320",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "καὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καθίστημι",
+          "strong": "G25250",
+          "x-morph": "Gr,V,SAA2,,S,",
+          "x-tw": "rc://*/tw/dict/bible/other/ordain",
+          "content": [
+            "καταστήσῃς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "κατά",
+          "strong": "G25960",
+          "x-morph": "Gr,P,,,,,A,,,",
+          "content": [
+            "κατὰ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πόλις",
+          "strong": "G41720",
+          "x-morph": "Gr,N,,,,,AFS,",
+          "content": [
+            "πόλιν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πρεσβύτερος",
+          "strong": "G42450",
+          "x-morph": "Gr,NS,,,,AMPC",
+          "x-tw": "rc://*/tw/dict/bible/other/elder",
+          "content": [
+            "πρεσβυτέρους"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὡς",
+          "strong": "G56130",
+          "x-morph": "Gr,CS,,,,,,,,",
+          "x-tw": "rc://*/tw/dict/bible/other/like",
+          "content": [
+            "ὡς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐγώ",
+          "strong": "G14730",
+          "x-morph": "Gr,RP,,,1N,S,",
+          "content": [
+            "ἐγώ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "σύ",
+          "strong": "G47710",
+          "x-morph": "Gr,RP,,,2D,S,",
+          "content": [
+            "σοι"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "διατάσσω",
+          "strong": "G12990",
+          "x-morph": "Gr,V,IAM1,,S,",
+          "x-tw": "rc://*/tw/dict/bible/other/ordain",
+          "content": [
+            "διεταξάμην"
+          ]
+        },
+        "; ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "6",
+          "sid": "TIT 1:6"
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "εἰ",
+          "strong": "G14870",
+          "x-morph": "Gr,CS,,,,,,,,",
+          "content": [
+            "εἴ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "τις",
+          "strong": "G51000",
+          "x-morph": "Gr,RI,,,,NMS,",
+          "content": [
+            "τίς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "εἰμί",
+          "strong": "G15100",
+          "x-morph": "Gr,V,IPA3,,S,",
+          "content": [
+            "ἐστιν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀνέγκλητος",
+          "strong": "G04100",
+          "x-morph": "Gr,NP,,,,NMS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/blameless",
+          "content": [
+            "ἀνέγκλητος"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "εἷς",
+          "strong": "G15200",
+          "x-morph": "Gr,EN,,,,GFS,",
+          "content": [
+            "μιᾶς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "γυνή",
+          "strong": "G11350",
+          "x-morph": "Gr,N,,,,,GFS,",
+          "content": [
+            "γυναικὸς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀνήρ",
+          "strong": "G04350",
+          "x-morph": "Gr,N,,,,,NMS,",
+          "content": [
+            "ἀνήρ"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "τέκνον",
+          "strong": "G50430",
+          "x-morph": "Gr,N,,,,,ANP,",
+          "x-tw": "rc://*/tw/dict/bible/kt/children",
+          "content": [
+            "τέκνα"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἔχω",
+          "strong": "G21920",
+          "x-morph": "Gr,V,PPA,NMS,",
+          "content": [
+            "ἔχων"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πιστός",
+          "strong": "G41030",
+          "x-morph": "Gr,NS,,,,ANP,",
+          "x-tw": "rc://*/tw/dict/bible/kt/faithful",
+          "content": [
+            "πιστά"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "μή",
+          "strong": "G33610",
+          "x-morph": "Gr,D,,,,,,,,,",
+          "content": [
+            "μὴ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐν",
+          "strong": "G17220",
+          "x-morph": "Gr,P,,,,,D,,,",
+          "content": [
+            "ἐν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "κατηγορία",
+          "strong": "G27240",
+          "x-morph": "Gr,N,,,,,DFS,",
+          "x-tw": "rc://*/tw/dict/bible/other/accuse",
+          "content": [
+            "κατηγορίᾳ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀσωτία",
+          "strong": "G08100",
+          "x-morph": "Gr,N,,,,,GFS,",
+          "content": [
+            "ἀσωτίας"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἤ",
+          "strong": "G22280",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "ἢ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀνυπότακτος",
+          "strong": "G05060",
+          "x-morph": "Gr,NP,,,,ANP,",
+          "x-tw": "rc://*/tw/dict/bible/other/rebel",
+          "content": [
+            "ἀνυπότακτα"
+          ]
+        },
+        ". ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "7",
+          "sid": "TIT 1:7"
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "δέω",
+          "strong": "G12100",
+          "x-morph": "Gr,V,IPA3,,S,",
+          "content": [
+            "δεῖ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "γάρ",
+          "strong": "G10630",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "γὰρ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,AMS,",
+          "content": [
+            "τὸν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐπίσκοπος",
+          "strong": "G19850",
+          "x-morph": "Gr,N,,,,,AMS,",
+          "x-tw": "rc://*/tw/dict/bible/other/overseer",
+          "content": [
+            "ἐπίσκοπον"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀνέγκλητος",
+          "strong": "G04100",
+          "x-morph": "Gr,NS,,,,AMS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/blameless",
+          "content": [
+            "ἀνέγκλητον"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "εἰμί",
+          "strong": "G15100",
+          "x-morph": "Gr,V,NPA,,,,,",
+          "content": [
+            "εἶναι"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὡς",
+          "strong": "G56130",
+          "x-morph": "Gr,CS,,,,,,,,",
+          "x-tw": "rc://*/tw/dict/bible/other/like",
+          "content": [
+            "ὡς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "θεός",
+          "strong": "G23160",
+          "x-morph": "Gr,N,,,,,GMS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/god",
+          "content": [
+            "Θεοῦ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "οἰκονόμος",
+          "strong": "G36230",
+          "x-morph": "Gr,N,,,,,AMS,",
+          "x-tw": "rc://*/tw/dict/bible/other/manager",
+          "content": [
+            "οἰκονόμον"
+          ]
+        },
+        "; ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "μή",
+          "strong": "G33610",
+          "x-morph": "Gr,D,,,,,,,,,",
+          "content": [
+            "μὴ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "αὐθάδης",
+          "strong": "G08290",
+          "x-morph": "Gr,NS,,,,AMS,",
+          "content": [
+            "αὐθάδη"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "μή",
+          "strong": "G33610",
+          "x-morph": "Gr,D,,,,,,,,,",
+          "content": [
+            "μὴ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὀργίλος",
+          "strong": "G37110",
+          "x-morph": "Gr,NS,,,,AMS,",
+          "x-tw": "rc://*/tw/dict/bible/other/angry",
+          "content": [
+            "ὀργίλον"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "μή",
+          "strong": "G33610",
+          "x-morph": "Gr,D,,,,,,,,,",
+          "content": [
+            "μὴ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πάροινος",
+          "strong": "G39430",
+          "x-morph": "Gr,NS,,,,AMS,",
+          "x-tw": "rc://*/tw/dict/bible/other/wine",
+          "content": [
+            "πάροινον"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "μή",
+          "strong": "G33610",
+          "x-morph": "Gr,D,,,,,,,,,",
+          "content": [
+            "μὴ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πλήκτης",
+          "strong": "G41310",
+          "x-morph": "Gr,N,,,,,AMS,",
+          "content": [
+            "πλήκτην"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "μή",
+          "strong": "G33610",
+          "x-morph": "Gr,D,,,,,,,,,",
+          "content": [
+            "μὴ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "αἰσχροκερδής",
+          "strong": "G01460",
+          "x-morph": "Gr,NS,,,,AMS,",
+          "content": [
+            "αἰσχροκερδῆ"
+          ]
+        },
+        ", ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "8",
+          "sid": "TIT 1:8"
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀλλά",
+          "strong": "G02350",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "ἀλλὰ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "φιλόξενος",
+          "strong": "G53820",
+          "x-morph": "Gr,NS,,,,AMS,",
+          "content": [
+            "φιλόξενον"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "φιλάγαθος",
+          "strong": "G53580",
+          "x-morph": "Gr,NS,,,,AMS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/good",
+          "content": [
+            "φιλάγαθον"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "σώφρων",
+          "strong": "G49980",
+          "x-morph": "Gr,NS,,,,AMS,",
+          "x-tw": "rc://*/tw/dict/bible/other/selfcontrol",
+          "content": [
+            "σώφρονα"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "δίκαιος",
+          "strong": "G13420",
+          "x-morph": "Gr,NS,,,,AMS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/righteous",
+          "content": [
+            "δίκαιον"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὅσιος",
+          "strong": "G37410",
+          "x-morph": "Gr,NS,,,,AMS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/holy",
+          "content": [
+            "ὅσιον"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐγκρατής",
+          "strong": "G14680",
+          "x-morph": "Gr,NS,,,,AMS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/discipline",
+          "content": [
+            "ἐgκρατῆ"
+          ]
+        },
+        "; ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "9",
+          "sid": "TIT 1:9"
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀντέχω",
+          "strong": "G04720",
+          "x-morph": "Gr,V,PPM,AMS,",
+          "content": [
+            "ἀντεχόμενον"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,GMS,",
+          "content": [
+            "τοῦ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "κατά",
+          "strong": "G25960",
+          "x-morph": "Gr,P,,,,,A,,,",
+          "content": [
+            "κατὰ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,AFS,",
+          "content": [
+            "τὴν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "διδαχή",
+          "strong": "G13220",
+          "x-morph": "Gr,N,,,,,AFS,",
+          "x-tw": "rc://*/tw/dict/bible/other/teach",
+          "content": [
+            "διδαχὴν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πιστός",
+          "strong": "G41030",
+          "x-morph": "Gr,AA,,,,GMS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/faithful",
+          "content": [
+            "πιστοῦ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "λόγος",
+          "strong": "G30560",
+          "x-morph": "Gr,N,,,,,GMS,",
+          "x-tw": "rc://*/tw/dict/bible/other/word",
+          "content": [
+            "λόγου"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἵνα",
+          "strong": "G24430",
+          "x-morph": "Gr,CS,,,,,,,,",
+          "content": [
+            "ἵνα"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "δυνατός",
+          "strong": "G14150",
+          "x-morph": "Gr,NS,,,,NMS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/power",
+          "content": [
+            "δυνατὸς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "εἰμί",
+          "strong": "G15100",
+          "x-morph": "Gr,V,SPA3,,S,",
+          "content": [
+            "ᾖ"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καί",
+          "strong": "G25320",
+          "x-morph": "Gr,DO,,,,,,,,",
+          "content": [
+            "καὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "παρακαλέω",
+          "strong": "G38700",
+          "x-morph": "Gr,V,NPA,,,,,",
+          "x-tw": "rc://*/tw/dict/bible/other/courage",
+          "content": [
+            "παρακαλεῖν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐν",
+          "strong": "G17220",
+          "x-morph": "Gr,P,,,,,D,,,",
+          "content": [
+            "ἐν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,DFS,",
+          "content": [
+            "τῇ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "διδασκαλία",
+          "strong": "G13190",
+          "x-morph": "Gr,N,,,,,DFS,",
+          "x-tw": "rc://*/tw/dict/bible/other/doctrine",
+          "content": [
+            "διδασκαλίᾳ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,RD,,,,DFS,",
+          "content": [
+            "τῇ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὑγιαίνω",
+          "strong": "G51980",
+          "x-morph": "Gr,V,PPA,DFS,",
+          "content": [
+            "ὑγιαινούσῃ"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καί",
+          "strong": "G25320",
+          "x-morph": "Gr,CO,,,,,,,,",
+          "content": [
+            "καὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,RD,,,,AMP,",
+          "content": [
+            "τοὺς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀντιλέγω",
+          "strong": "G04830",
+          "x-morph": "Gr,V,PPA,AMP,",
+          "content": [
+            "ἀντιλέγοντας"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐλέγχω",
+          "strong": "G16510",
+          "x-morph": "Gr,V,NPA,,,,,",
+          "x-tw": "rc://*/tw/dict/bible/other/rebuke",
+          "content": [
+            "ἐλέγχειν"
+          ]
+        },
+        ". ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "10",
+          "sid": "TIT 1:10"
+        }
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "εἰμί",
+          "strong": "G15100",
+          "x-morph": "Gr,V,IPA3,,P,",
+          "content": [
+            "εἰσὶν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "γάρ",
+          "strong": "G10630",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "γὰρ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πολλός",
+          "strong": "G41830",
+          "x-morph": "Gr,RI,,,,NMP,",
+          "content": [
+            "πολλοὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καί",
+          "strong": "G25320",
+          "x-morph": "Gr,D,,,,,,,,,",
+          "content": [
+            "καὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀνυπότακτος",
+          "strong": "G05060",
+          "x-morph": "Gr,NS,,,,NMP,",
+          "x-tw": "rc://*/tw/dict/bible/other/rebel",
+          "content": [
+            "ἀνυπότακτοι"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ματαιολόγος",
+          "strong": "G31510",
+          "x-morph": "Gr,NS,,,,NMP,",
+          "x-tw": "rc://*/tw/dict/bible/other/vain",
+          "content": [
+            "ματαιολόγοι"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καί",
+          "strong": "G25320",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "καὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "φρεναπάτης",
+          "strong": "G54230",
+          "x-morph": "Gr,N,,,,,NMP,",
+          "x-tw": "rc://*/tw/dict/bible/other/deceive",
+          "content": [
+            "φρεναπάται"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "μάλιστα",
+          "strong": "G31220",
+          "x-morph": "Gr,D,,,,,,,,S",
+          "content": [
+            "μάλιστα"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,RD,,,,NMP,",
+          "content": [
+            "οἱ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐκ",
+          "strong": "G15370",
+          "x-morph": "Gr,P,,,,,G,,,",
+          "content": [
+            "ἐκ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,GFS,",
+          "content": [
+            "τῆς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "περιτομή",
+          "strong": "G40610",
+          "x-morph": "Gr,N,,,,,GFS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/circumcise",
+          "content": [
+            "περιτομῆς"
+          ]
+        },
+        ", ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "11",
+          "sid": "TIT 1:11"
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὅς",
+          "strong": "G37390",
+          "x-morph": "Gr,RR,,,,AMP,",
+          "content": [
+            "οὓς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "δέω",
+          "strong": "G12100",
+          "x-morph": "Gr,V,IPA3,,S,",
+          "content": [
+            "δεῖ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐπιστομίζω",
+          "strong": "G19930",
+          "x-morph": "Gr,V,NPA,,,,,",
+          "content": [
+            "ἐπιστομίζειν"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὅστις",
+          "strong": "G37480",
+          "x-morph": "Gr,RR,,,,NMP,",
+          "content": [
+            "οἵτινες"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὅλος",
+          "strong": "G36500",
+          "x-morph": "Gr,EQ,,,,AMP,",
+          "content": [
+            "ὅλους"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "οἶκος",
+          "strong": "G36240",
+          "x-morph": "Gr,N,,,,,AMP,",
+          "x-tw": "rc://*/tw/dict/bible/other/household",
+          "content": [
+            "οἴκους"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀνατρέπω",
+          "strong": "G03960",
+          "x-morph": "Gr,V,IPA3,,P,",
+          "content": [
+            "ἀνατρέπουσιν"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "διδάσκω",
+          "strong": "G13210",
+          "x-morph": "Gr,V,PPA,NMP,",
+          "x-tw": "rc://*/tw/dict/bible/other/teach",
+          "content": [
+            "διδάσκοντες"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὅς",
+          "strong": "G37390",
+          "x-morph": "Gr,RD,,,,ANP,",
+          "content": [
+            "ἃ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "μή",
+          "strong": "G33610",
+          "x-morph": "Gr,D,,,,,,,,,",
+          "content": [
+            "μὴ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "δέω",
+          "strong": "G12100",
+          "x-morph": "Gr,V,IPA3,,S,",
+          "content": [
+            "δεῖ"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "αἰσχρός",
+          "strong": "G01500",
+          "x-morph": "Gr,AA,,,,GNS,",
+          "x-tw": "rc://*/tw/dict/bible/other/shame",
+          "content": [
+            "αἰσχροῦ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "κέρδος",
+          "strong": "G27710",
+          "x-morph": "Gr,N,,,,,GNS,",
+          "x-tw": "rc://*/tw/dict/bible/other/profit",
+          "content": [
+            "κέρδους"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "χάριν",
+          "strong": "G54840",
+          "x-morph": "Gr,PI,,,,G,,,",
+          "content": [
+            "χάριν"
+          ]
+        },
+        ". ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "12",
+          "sid": "TIT 1:12"
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "λέγω",
+          "strong": "G30040",
+          "x-morph": "Gr,V,IAA3,,S,",
+          "content": [
+            "εἶπέν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "τις",
+          "strong": "G51000",
+          "x-morph": "Gr,RI,,,,NMS,",
+          "content": [
+            "τις"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐκ",
+          "strong": "G15370",
+          "x-morph": "Gr,P,,,,,G,,,",
+          "content": [
+            "ἐξ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "αὐτός",
+          "strong": "G08460",
+          "x-morph": "Gr,RP,,,3GMP,",
+          "content": [
+            "αὐτῶν"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἴδιος",
+          "strong": "G23980",
+          "x-morph": "Gr,RD,,,,NMS,",
+          "content": [
+            "ἴδιος"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "αὐτός",
+          "strong": "G08460",
+          "x-morph": "Gr,RP,,,3GMP,",
+          "content": [
+            "αὐτῶν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "προφήτης",
+          "strong": "G43960",
+          "x-morph": "Gr,N,,,,,NMS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/prophet",
+          "content": [
+            "προφήτης"
+          ]
+        },
+        ", “",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "Κρής",
+          "strong": "G29120",
+          "x-morph": "Gr,N,,,,,NMP,",
+          "x-tw": "rc://*/tw/dict/bible/names/crete",
+          "content": [
+            "Κρῆτες"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀεί",
+          "strong": "G01040",
+          "x-morph": "Gr,D,,,,,,,,,",
+          "content": [
+            "ἀεὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ψεύστης",
+          "strong": "G55830",
+          "x-morph": "Gr,N,,,,,NMP,",
+          "content": [
+            "ψεῦσται"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "κακός",
+          "strong": "G25560",
+          "x-morph": "Gr,AA,,,,NNP,",
+          "x-tw": "rc://*/tw/dict/bible/kt/evil",
+          "content": [
+            "κακὰ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "θηρίον",
+          "strong": "G23420",
+          "x-morph": "Gr,N,,,,,NNP,",
+          "x-tw": "rc://*/tw/dict/bible/other/beast",
+          "content": [
+            "θηρία"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "γαστήρ",
+          "strong": "G10640",
+          "x-morph": "Gr,N,,,,,NFP,",
+          "x-tw": "rc://*/tw/dict/bible/other/womb",
+          "content": [
+            "γαστέρες"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀργός",
+          "strong": "G06920",
+          "x-morph": "Gr,AA,,,,NFP,",
+          "content": [
+            "ἀργαί"
+          ]
+        },
+        ".” ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "13",
+          "sid": "TIT 1:13"
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,NFS,",
+          "content": [
+            "ἡ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "μαρτυρία",
+          "strong": "G31410",
+          "x-morph": "Gr,N,,,,,NFS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/testimony",
+          "content": [
+            "μαρτυρία"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "οὗτος",
+          "strong": "G37780",
+          "x-morph": "Gr,ED,,,,NFS,",
+          "content": [
+            "αὕτη"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "εἰμί",
+          "strong": "G15100",
+          "x-morph": "Gr,V,IPA3,,S,",
+          "content": [
+            "ἐστὶν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀληθής",
+          "strong": "G02270",
+          "x-morph": "Gr,NP,,,,NFS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/true",
+          "content": [
+            "ἀληθής"
+          ]
+        },
+        ". ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "διά",
+          "strong": "G12230",
+          "x-morph": "Gr,P,,,,,A,,,",
+          "content": [
+            "δι’"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὅς",
+          "strong": "G37390",
+          "x-morph": "Gr,ER,,,,AFS,",
+          "content": [
+            "ἣν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "αἰτία",
+          "strong": "G01560",
+          "x-morph": "Gr,N,,,,,AFS,",
+          "content": [
+            "αἰτίαν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐλέγχω",
+          "strong": "G16510",
+          "x-morph": "Gr,V,MPA2,,S,",
+          "x-tw": "rc://*/tw/dict/bible/other/rebuke",
+          "content": [
+            "ἔλεγχε"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "αὐτός",
+          "strong": "G08460",
+          "x-morph": "Gr,RP,,,3AMP,",
+          "content": [
+            "αὐτοὺς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀποτόμως",
+          "strong": "G06640",
+          "x-morph": "Gr,D,,,,,,,,,",
+          "content": [
+            "ἀποτόμως"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἵνα",
+          "strong": "G24430",
+          "x-morph": "Gr,CS,,,,,,,,",
+          "content": [
+            "ἵνα"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὑγιαίνω",
+          "strong": "G51980",
+          "x-morph": "Gr,V,SPA3,,P,",
+          "content": [
+            "ὑγιαίνωσιν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐν",
+          "strong": "G17220",
+          "x-morph": "Gr,P,,,,,D,,,",
+          "content": [
+            "ἐν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,DFS,",
+          "content": [
+            "τῇ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πίστις",
+          "strong": "G41020",
+          "x-morph": "Gr,N,,,,,DFS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/faith",
+          "content": [
+            "πίστει"
+          ]
+        },
+        ", ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "14",
+          "sid": "TIT 1:14"
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "μή",
+          "strong": "G33610",
+          "x-morph": "Gr,D,,,,,,,,,",
+          "content": [
+            "μὴ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "προσέχω",
+          "strong": "G43370",
+          "x-morph": "Gr,V,PPA,NMP,",
+          "content": [
+            "προσέχοντες"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "Ἰουδαϊκός",
+          "strong": "G24510",
+          "x-morph": "Gr,AA,,,,DMP,",
+          "x-tw": "rc://*/tw/dict/bible/kt/jew",
+          "content": [
+            "Ἰουδαϊκοῖς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "μῦθος",
+          "strong": "G34540",
+          "x-morph": "Gr,N,,,,,DMP,",
+          "content": [
+            "μύθοις"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καί",
+          "strong": "G25320",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "καὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐντολή",
+          "strong": "G17850",
+          "x-morph": "Gr,N,,,,,DFP,",
+          "x-tw": "rc://*/tw/dict/bible/kt/command",
+          "content": [
+            "ἐντολαῖς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἄνθρωπος",
+          "strong": "G04440",
+          "x-morph": "Gr,N,,,,,GMP,",
+          "content": [
+            "ἀνθρώπων"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀποστρέφω",
+          "strong": "G06540",
+          "x-morph": "Gr,V,PPM,GMP,",
+          "x-tw": "rc://*/tw/dict/bible/other/turn",
+          "content": [
+            "ἀποστρεφομένων"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,AFS,",
+          "content": [
+            "τὴν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀλήθεια",
+          "strong": "G02250",
+          "x-morph": "Gr,N,,,,,AFS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/true",
+          "content": [
+            "ἀλήθειαν"
+          ]
+        },
+        ". ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "15",
+          "sid": "TIT 1:15"
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πᾶς",
+          "strong": "G39560",
+          "x-morph": "Gr,RI,,,,NNP,",
+          "content": [
+            "πάντα"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καθαρός",
+          "strong": "G25130",
+          "x-morph": "Gr,NP,,,,NNP,",
+          "x-tw": "rc://*/tw/dict/bible/kt/purify",
+          "content": [
+            "καθαρὰ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,DMP,",
+          "content": [
+            "τοῖς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καθαρός",
+          "strong": "G25130",
+          "x-morph": "Gr,NS,,,,DMP,",
+          "x-tw": "rc://*/tw/dict/bible/kt/purify",
+          "content": [
+            "καθαροῖς"
+          ]
+        },
+        "; ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,RD,,,,DMP,",
+          "content": [
+            "τοῖς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "δέ",
+          "strong": "G11610",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "δὲ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "μιαίνω",
+          "strong": "G33920",
+          "x-morph": "Gr,V,PEP,DMP,",
+          "x-tw": "rc://*/tw/dict/bible/other/defile",
+          "content": [
+            "μεμιαμμένοις"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καί",
+          "strong": "G25320",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "καὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἄπιστος",
+          "strong": "G05710",
+          "x-morph": "Gr,NS,,,,DMP,",
+          "x-tw": "rc://*/tw/dict/bible/kt/believe",
+          "content": [
+            "ἀπίστοις"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "οὐδείς",
+          "strong": "G37620",
+          "x-morph": "Gr,RI,,,,NNS,",
+          "content": [
+            "οὐδὲν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καθαρός",
+          "strong": "G25130",
+          "x-morph": "Gr,NP,,,,NNS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/purify",
+          "content": [
+            "καθαρόν"
+          ]
+        },
+        "; ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀλλά",
+          "strong": "G02350",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "ἀλλὰ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "μιαίνω",
+          "strong": "G33920",
+          "x-morph": "Gr,V,IEP3,,S,",
+          "x-tw": "rc://*/tw/dict/bible/other/defile",
+          "content": [
+            "μεμίανται"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "αὐτός",
+          "strong": "G08460",
+          "x-morph": "Gr,RP,,,3GMP,",
+          "content": [
+            "αὐτῶν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καί",
+          "strong": "G25320",
+          "x-morph": "Gr,DO,,,,,,,,",
+          "content": [
+            "καὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,NMS,",
+          "content": [
+            "ὁ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "νοῦς",
+          "strong": "G35630",
+          "x-morph": "Gr,N,,,,,NMS,",
+          "x-tw": "rc://*/tw/dict/bible/other/mind",
+          "content": [
+            "νοῦς"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καί",
+          "strong": "G25320",
+          "x-morph": "Gr,CO,,,,,,,,",
+          "content": [
+            "καὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,NFS,",
+          "content": [
+            "ἡ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "συνείδησις",
+          "strong": "G48930",
+          "x-morph": "Gr,N,,,,,NFS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/conscience",
+          "content": [
+            "συνείδησις"
+          ]
+        },
+        ". ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "16",
+          "sid": "TIT 1:16"
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "θεός",
+          "strong": "G23160",
+          "x-morph": "Gr,N,,,,,AMS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/god",
+          "content": [
+            "Θεὸν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁμολογέω",
+          "strong": "G36700",
+          "x-morph": "Gr,V,IPA3,,P,",
+          "x-tw": "rc://*/tw/dict/bible/kt/confess",
+          "content": [
+            "ὁμολογοῦσιν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "εἴδω",
+          "strong": "G14920",
+          "x-morph": "Gr,V,NEA,,,,,",
+          "x-tw": "rc://*/tw/dict/bible/other/know",
+          "content": [
+            "εἰδέναι"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EP,,,,DNP,",
+          "content": [
+            "τοῖς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "δέ",
+          "strong": "G11610",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "δὲ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἔργον",
+          "strong": "G20410",
+          "x-morph": "Gr,N,,,,,DNP,",
+          "x-tw": "rc://*/tw/dict/bible/kt/works",
+          "content": [
+            "ἔργοις"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀρνέομαι",
+          "strong": "G07200",
+          "x-morph": "Gr,V,IPM3,,P,",
+          "content": [
+            "ἀρνοῦνται"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "βδελυκτός",
+          "strong": "G09470",
+          "x-morph": "Gr,NS,,,,NMP,",
+          "x-tw": "rc://*/tw/dict/bible/other/detestable",
+          "content": [
+            "βδελυκτοὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "εἰμί",
+          "strong": "G15100",
+          "x-morph": "Gr,V,PPA,NMP,",
+          "content": [
+            "ὄντες"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καί",
+          "strong": "G25320",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "καὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀπειθής",
+          "strong": "G05450",
+          "x-morph": "Gr,NS,,,,NMP,",
+          "x-tw": "rc://*/tw/dict/bible/other/disobey",
+          "content": [
+            "ἀπειθεῖς"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καί",
+          "strong": "G25320",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "καὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πρός",
+          "strong": "G43140",
+          "x-morph": "Gr,P,,,,,A,,,",
+          "content": [
+            "πρὸς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πᾶς",
+          "strong": "G39560",
+          "x-morph": "Gr,EQ,,,,ANS,",
+          "content": [
+            "πᾶν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἔργον",
+          "strong": "G20410",
+          "x-morph": "Gr,N,,,,,ANS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/works",
+          "content": [
+            "ἔργον"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀγαθός",
+          "strong": "G00180",
+          "x-morph": "Gr,AA,,,,ANS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/good",
+          "content": [
+            "ἀγαθὸν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀδόκιμος",
+          "strong": "G00960",
+          "x-morph": "Gr,NS,,,,NMP,",
+          "content": [
+            "ἀδόκιμοι"
+          ]
+        },
+        "."
+      ]
+    },
+    {
+      "type": "chapter",
+      "marker": "c",
+      "number": "2",
+      "sid": "TIT 2"
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "1",
+          "sid": "TIT 2:1"
+        }
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "σύ",
+          "strong": "G47710",
+          "x-morph": "Gr,RP,,,2N,S,",
+          "content": [
+            "σὺ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "δέ",
+          "strong": "G11610",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "δὲ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "λαλέω",
+          "strong": "G29800",
+          "x-morph": "Gr,V,MPA2,,S,",
+          "content": [
+            "λάλει"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὅς",
+          "strong": "G37390",
+          "x-morph": "Gr,RD,,,,ANP,",
+          "content": [
+            "ἃ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πρέπω",
+          "strong": "G42410",
+          "x-morph": "Gr,V,IPA3,,S,",
+          "content": [
+            "πρέπει"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,RD,,,,DFS,",
+          "content": [
+            "τῇ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὑγιαίνω",
+          "strong": "G51980",
+          "x-morph": "Gr,V,PPA,DFS,",
+          "content": [
+            "ὑγιαινούσῃ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "διδασκαλία",
+          "strong": "G13190",
+          "x-morph": "Gr,N,,,,,DFS,",
+          "x-tw": "rc://*/tw/dict/bible/other/doctrine",
+          "content": [
+            "διδασκαλίᾳ"
+          ]
+        },
+        ". ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "2",
+          "sid": "TIT 2:2"
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πρεσβύτης",
+          "strong": "G42460",
+          "x-morph": "Gr,N,,,,,AMP,",
+          "x-tw": "rc://*/tw/dict/bible/other/elder",
+          "content": [
+            "πρεσβύτας"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "νηφάλιος",
+          "strong": "G35240",
+          "x-morph": "Gr,NS,,,,AMP,",
+          "content": [
+            "νηφαλίους"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "εἰμί",
+          "strong": "G15100",
+          "x-morph": "Gr,V,NPA,,,,,",
+          "content": [
+            "εἶναι"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "σεμνός",
+          "strong": "G45860",
+          "x-morph": "Gr,NP,,,,AMP,",
+          "x-tw": "rc://*/tw/dict/bible/kt/honor",
+          "content": [
+            "σεμνούς"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "σώφρων",
+          "strong": "G49980",
+          "x-morph": "Gr,NS,,,,AMP,",
+          "x-tw": "rc://*/tw/dict/bible/other/selfcontrol",
+          "content": [
+            "σώφρονας"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὑγιαίνω",
+          "strong": "G51980",
+          "x-morph": "Gr,V,PPA,AMP,",
+          "content": [
+            "ὑγιαίνοντας"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,DFS,",
+          "content": [
+            "τῇ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πίστις",
+          "strong": "G41020",
+          "x-morph": "Gr,N,,,,,DFS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/faith",
+          "content": [
+            "πίστει"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,DFS,",
+          "content": [
+            "τῇ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀγάπη",
+          "strong": "G00260",
+          "x-morph": "Gr,N,,,,,DFS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/love",
+          "content": [
+            "ἀγάπῃ"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,DFS,",
+          "content": [
+            "τῇ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὑπομονή",
+          "strong": "G52810",
+          "x-morph": "Gr,N,,,,,DFS,",
+          "x-tw": "rc://*/tw/dict/bible/other/perseverance",
+          "content": [
+            "ὑπομονῇ"
+          ]
+        },
+        ". ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "3",
+          "sid": "TIT 2:3"
+        }
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πρεσβῦτις",
+          "strong": "G42470",
+          "x-morph": "Gr,N,,,,,AFP,",
+          "content": [
+            "πρεσβύτιδας"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὡσαύτως",
+          "strong": "G56150",
+          "x-morph": "Gr,D,,,,,,,,,",
+          "x-tw": "rc://*/tw/dict/bible/other/like",
+          "content": [
+            "ὡσαύτως"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐν",
+          "strong": "G17220",
+          "x-morph": "Gr,P,,,,,D,,,",
+          "content": [
+            "ἐν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "κατάστημα",
+          "strong": "G26880",
+          "x-morph": "Gr,N,,,,,DNS,",
+          "content": [
+            "καταστήματι"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἱεροπρεπής",
+          "strong": "G24120",
+          "x-morph": "Gr,NS,,,,AFP,",
+          "x-tw": "rc://*/tw/dict/bible/other/reverence",
+          "content": [
+            "ἱεροπρεπεῖς"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "μή",
+          "strong": "G33610",
+          "x-morph": "Gr,D,,,,,,,,,",
+          "content": [
+            "μὴ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "διάβολος",
+          "strong": "G12280",
+          "x-morph": "Gr,NS,,,,AFP,",
+          "x-tw": "rc://*/tw/dict/bible/other/slander",
+          "content": [
+            "διαβόλους"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "μηδέ",
+          "strong": "G33660",
+          "x-morph": "Gr,D,,,,,,,,,",
+          "content": [
+            "μηδὲ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "οἶνος",
+          "strong": "G36310",
+          "x-morph": "Gr,N,,,,,DMS,",
+          "x-tw": "rc://*/tw/dict/bible/other/wine",
+          "content": [
+            "οἴνῳ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πολλός",
+          "strong": "G41830",
+          "x-morph": "Gr,EQ,,,,DMS,",
+          "content": [
+            "πολλῷ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "δουλόω",
+          "strong": "G14020",
+          "x-morph": "Gr,V,PEP,AFP,",
+          "x-tw": "rc://*/tw/dict/bible/other/enslave",
+          "content": [
+            "δεδουλωμένας"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καλοδιδάσκαλος",
+          "strong": "G25670",
+          "x-morph": "Gr,NS,,,,AFP,",
+          "content": [
+            "καλοδιδασκάλους"
+          ]
+        },
+        ", ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "4",
+          "sid": "TIT 2:4"
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἵνα",
+          "strong": "G24430",
+          "x-morph": "Gr,CS,,,,,,,,",
+          "content": [
+            "ἵνα"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "σωφρονίζω",
+          "strong": "G49940",
+          "x-morph": "Gr,V,SPA3,,P,",
+          "content": [
+            "σωφρονίζωσι"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,AFP,",
+          "content": [
+            "τὰς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "νέος",
+          "strong": "G35010",
+          "x-morph": "Gr,NS,,,,AFP,",
+          "content": [
+            "νέας"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "φίλανδρος",
+          "strong": "G53620",
+          "x-morph": "Gr,NS,,,,AFP,",
+          "x-tw": "rc://*/tw/dict/bible/kt/love",
+          "content": [
+            "φιλάνδρους"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "εἰμί",
+          "strong": "G15100",
+          "x-morph": "Gr,V,NPA,,,,,",
+          "content": [
+            "εἶναι"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "φιλότεκνος",
+          "strong": "G53880",
+          "x-morph": "Gr,NS,,,,AFP,",
+          "x-tw": "rc://*/tw/dict/bible/kt/love",
+          "content": [
+            "φιλοτέκνους"
+          ]
+        },
+        ", ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "5",
+          "sid": "TIT 2:5"
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "σώφρων",
+          "strong": "G49980",
+          "x-morph": "Gr,NS,,,,AFP,",
+          "x-tw": "rc://*/tw/dict/bible/other/selfcontrol",
+          "content": [
+            "σώφρονας"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἁγνός",
+          "strong": "G00530",
+          "x-morph": "Gr,NS,,,,AFP,",
+          "x-tw": "rc://*/tw/dict/bible/kt/purify",
+          "content": [
+            "ἁγνάς"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "οἰκουργός",
+          "strong": "G36260",
+          "x-morph": "Gr,NS,,,,AFP,",
+          "x-tw": "rc://*/tw/dict/bible/other/household",
+          "content": [
+            "οἰκουργούς"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀγαθός",
+          "strong": "G00180",
+          "x-morph": "Gr,NS,,,,AFP,",
+          "x-tw": "rc://*/tw/dict/bible/kt/good",
+          "content": [
+            "ἀγαθάς"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὑποτάσσω",
+          "strong": "G52930",
+          "x-morph": "Gr,V,PPP,AFP,",
+          "x-tw": "rc://*/tw/dict/bible/other/subject",
+          "content": [
+            "ὑποτασσομένας"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EP,,,,DMP,",
+          "content": [
+            "τοῖς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἴδιος",
+          "strong": "G23980",
+          "x-morph": "Gr,EF,,,,DMP,",
+          "content": [
+            "ἰδίοις"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀνήρ",
+          "strong": "G04350",
+          "x-morph": "Gr,N,,,,,DMP,",
+          "content": [
+            "ἀνδράσιν"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἵνα",
+          "strong": "G24430",
+          "x-morph": "Gr,CS,,,,,,,,",
+          "content": [
+            "ἵνα"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "μή",
+          "strong": "G33610",
+          "x-morph": "Gr,D,,,,,,,,,",
+          "content": [
+            "μὴ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,NMS,",
+          "content": [
+            "ὁ"
+          ]
+        },
+        " \\k-s| x-tw=\"rc:",
+        {
+          "type": "optbreak"
+        },
+        "*/tw/dict/bible/kt/wordofgod\"\n",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "λόγος",
+          "strong": "G30560",
+          "x-morph": "Gr,N,,,,,NMS,",
+          "content": [
+            "λόγος"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,GMS,",
+          "content": [
+            "τοῦ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "θεός",
+          "strong": "G23160",
+          "x-morph": "Gr,N,,,,,GMS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/god",
+          "content": [
+            "Θεοῦ"
+          ]
+        },
+        {
+          "type": "ms",
+          "marker": "k-e"
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "βλασφημέω",
+          "strong": "G09870",
+          "x-morph": "Gr,V,SPP3,,S,",
+          "x-tw": "rc://*/tw/dict/bible/kt/blasphemy",
+          "content": [
+            "βλασφημῆται"
+          ]
+        },
+        ". ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "6",
+          "sid": "TIT 2:6"
+        }
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,AMP,",
+          "content": [
+            "τοὺς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "νεώτερος",
+          "strong": "G35125",
+          "x-morph": "Gr,AA,,,,AMPC",
+          "content": [
+            "νεωτέρους"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὡσαύτως",
+          "strong": "G56150",
+          "x-morph": "Gr,D,,,,,,,,,",
+          "x-tw": "rc://*/tw/dict/bible/other/like",
+          "content": [
+            "ὡσαύτως"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "παρακαλέω",
+          "strong": "G38700",
+          "x-morph": "Gr,V,MPA2,,S,",
+          "x-tw": "rc://*/tw/dict/bible/kt/exhort",
+          "content": [
+            "παρακάλει"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "σωφρονέω",
+          "strong": "G49930",
+          "x-morph": "Gr,V,NPA,,,,,",
+          "x-tw": "rc://*/tw/dict/bible/other/selfcontrol",
+          "content": [
+            "σωφρονεῖν"
+          ]
+        },
+        "; ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "7",
+          "sid": "TIT 2:7"
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "περί",
+          "strong": "G40120",
+          "x-morph": "Gr,P,,,,,A,,,",
+          "content": [
+            "περὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πᾶς",
+          "strong": "G39560",
+          "x-morph": "Gr,RI,,,,ANP,",
+          "content": [
+            "πάντα"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "σεαυτοῦ",
+          "strong": "G45720",
+          "x-morph": "Gr,RE,,,2AMS,",
+          "content": [
+            "σεαυτὸν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "παρέχω",
+          "strong": "G39300",
+          "x-morph": "Gr,V,PPM,NMS,",
+          "content": [
+            "παρεχόμενος"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "τύπος",
+          "strong": "G51790",
+          "x-morph": "Gr,N,,,,,AMS,",
+          "content": [
+            "τύπον"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καλός",
+          "strong": "G25700",
+          "x-morph": "Gr,AA,,,,GNP,",
+          "x-tw": "rc://*/tw/dict/bible/kt/good",
+          "content": [
+            "καλῶν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἔργον",
+          "strong": "G20410",
+          "x-morph": "Gr,N,,,,,GNP,",
+          "x-tw": "rc://*/tw/dict/bible/kt/works",
+          "content": [
+            "ἔργων"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐν",
+          "strong": "G17220",
+          "x-morph": "Gr,P,,,,,D,,,",
+          "content": [
+            "ἐν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EP,,,,DFS,",
+          "content": [
+            "τῇ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "διδασκαλία",
+          "strong": "G13190",
+          "x-morph": "Gr,N,,,,,DFS,",
+          "x-tw": "rc://*/tw/dict/bible/other/doctrine",
+          "content": [
+            "διδασκαλίᾳ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀφθορία",
+          "strong": "G08627",
+          "x-morph": "Gr,N,,,,,AFS,",
+          "x-tw": "rc://*/tw/dict/bible/other/integrity",
+          "content": [
+            "ἀφθορίαν"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "σεμνότης",
+          "strong": "G45870",
+          "x-morph": "Gr,N,,,,,AFS,",
+          "content": [
+            "σεμνότητα"
+          ]
+        },
+        ", ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "8",
+          "sid": "TIT 2:8"
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "λόγος",
+          "strong": "G30560",
+          "x-morph": "Gr,N,,,,,AMS,",
+          "x-tw": "rc://*/tw/dict/bible/other/word",
+          "content": [
+            "λόγον"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὑγιής",
+          "strong": "G51990",
+          "x-morph": "Gr,AA,,,,AMS,",
+          "content": [
+            "ὑγιῆ"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀκατάγνωστος",
+          "strong": "G01760",
+          "x-morph": "Gr,NS,,,,AMS,",
+          "content": [
+            "ἀκατάγνωστον"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἵνα",
+          "strong": "G24430",
+          "x-morph": "Gr,CS,,,,,,,,",
+          "content": [
+            "ἵνα"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,RD,,,,NMS,",
+          "content": [
+            "ὁ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐκ",
+          "strong": "G15370",
+          "x-morph": "Gr,P,,,,,G,,,",
+          "content": [
+            "ἐξ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐναντίος",
+          "strong": "G17270",
+          "x-morph": "Gr,NS,,,,GFS,",
+          "content": [
+            "ἐναντίας"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐντρέπω",
+          "strong": "G17880",
+          "x-morph": "Gr,V,SAP3,,S,",
+          "x-tw": "rc://*/tw/dict/bible/other/shame",
+          "content": [
+            "ἐντραπῇ"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "μηδείς",
+          "strong": "G33670",
+          "x-morph": "Gr,RI,,,,ANS,",
+          "content": [
+            "μηδὲν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἔχω",
+          "strong": "G21920",
+          "x-morph": "Gr,V,PPA,NMS,",
+          "content": [
+            "ἔχων"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "λέγω",
+          "strong": "G30040",
+          "x-morph": "Gr,V,NPA,,,,,",
+          "content": [
+            "λέγειν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "περί",
+          "strong": "G40120",
+          "x-morph": "Gr,P,,,,,G,,,",
+          "content": [
+            "περὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐγώ",
+          "strong": "G14730",
+          "x-morph": "Gr,RP,,,1G,P,",
+          "content": [
+            "ἡμῶν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "φαῦλος",
+          "strong": "G53370",
+          "x-morph": "Gr,NS,,,,ANS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/evil",
+          "content": [
+            "φαῦλον"
+          ]
+        },
+        ". ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "9",
+          "sid": "TIT 2:9"
+        }
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "δοῦλος",
+          "strong": "G14010",
+          "x-morph": "Gr,N,,,,,AMP,",
+          "x-tw": "rc://*/tw/dict/bible/other/servant",
+          "content": [
+            "δούλους"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἴδιος",
+          "strong": "G23980",
+          "x-morph": "Gr,EF,,,,DMP,",
+          "content": [
+            "ἰδίοις"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "δεσπότης",
+          "strong": "G12030",
+          "x-morph": "Gr,N,,,,,DMP,",
+          "x-tw": "rc://*/tw/dict/bible/kt/lord",
+          "content": [
+            "δεσπόταις"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὑποτάσσω",
+          "strong": "G52930",
+          "x-morph": "Gr,V,NPM,,,,,",
+          "x-tw": "rc://*/tw/dict/bible/other/subject",
+          "content": [
+            "ὑποτάσσεσθαι"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐν",
+          "strong": "G17220",
+          "x-morph": "Gr,P,,,,,D,,,",
+          "content": [
+            "ἐν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πᾶς",
+          "strong": "G39560",
+          "x-morph": "Gr,RI,,,,DNP,",
+          "content": [
+            "πᾶσιν"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "εὐάρεστος",
+          "strong": "G21010",
+          "x-morph": "Gr,NP,,,,AMP,",
+          "content": [
+            "εὐαρέστους"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "εἰμί",
+          "strong": "G15100",
+          "x-morph": "Gr,V,NPA,,,,,",
+          "content": [
+            "εἶναι"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "μή",
+          "strong": "G33610",
+          "x-morph": "Gr,D,,,,,,,,,",
+          "content": [
+            "μὴ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀντιλέγω",
+          "strong": "G04830",
+          "x-morph": "Gr,V,PPA,AMP,",
+          "content": [
+            "ἀντιλέγοντας"
+          ]
+        },
+        ", ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "10",
+          "sid": "TIT 2:10"
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "μή",
+          "strong": "G33610",
+          "x-morph": "Gr,D,,,,,,,,,",
+          "content": [
+            "μὴ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "νοσφίζω",
+          "strong": "G35570",
+          "x-morph": "Gr,V,PPM,AMP,",
+          "content": [
+            "νοσφιζομένους"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀλλά",
+          "strong": "G02350",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "ἀλλὰ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πᾶς",
+          "strong": "G39560",
+          "x-morph": "Gr,EQ,,,,AFS,",
+          "content": [
+            "πᾶσαν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πίστις",
+          "strong": "G41020",
+          "x-morph": "Gr,N,,,,,AFS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/faith",
+          "content": [
+            "πίστιν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐνδείκνυμι",
+          "strong": "G17310",
+          "x-morph": "Gr,V,PPM,AMP,",
+          "content": [
+            "ἐνδεικνυμένους"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀγαθός",
+          "strong": "G00180",
+          "x-morph": "Gr,NS,,,,AFS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/good",
+          "content": [
+            "ἀγαθήν"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἵνα",
+          "strong": "G24430",
+          "x-morph": "Gr,CS,,,,,,,,",
+          "content": [
+            "ἵνα"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,AFS,",
+          "content": [
+            "τὴν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "διδασκαλία",
+          "strong": "G13190",
+          "x-morph": "Gr,N,,,,,AFS,",
+          "x-tw": "rc://*/tw/dict/bible/other/doctrine",
+          "content": [
+            "διδασκαλίαν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,RD,,,,AFS,",
+          "content": [
+            "τὴν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,GMS,",
+          "content": [
+            "τοῦ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "σωτήρ",
+          "strong": "G49900",
+          "x-morph": "Gr,N,,,,,GMS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/savior",
+          "content": [
+            "Σωτῆρος"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐγώ",
+          "strong": "G14730",
+          "x-morph": "Gr,RP,,,1G,P,",
+          "content": [
+            "ἡμῶν"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "θεός",
+          "strong": "G23160",
+          "x-morph": "Gr,N,,,,,GMS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/god",
+          "content": [
+            "Θεοῦ"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "κοσμέω",
+          "strong": "G28850",
+          "x-morph": "Gr,V,SPA3,,P,",
+          "content": [
+            "κοσμῶσιν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐν",
+          "strong": "G17220",
+          "x-morph": "Gr,P,,,,,D,,,",
+          "content": [
+            "ἐν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πᾶς",
+          "strong": "G39560",
+          "x-morph": "Gr,RI,,,,DNP,",
+          "content": [
+            "πᾶσιν"
+          ]
+        },
+        ". ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "11",
+          "sid": "TIT 2:11"
+        }
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐπιφαίνω",
+          "strong": "G20140",
+          "x-morph": "Gr,V,IAP3,,S,",
+          "content": [
+            "ἐπεφάνη"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "γάρ",
+          "strong": "G10630",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "γὰρ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,NFS,",
+          "content": [
+            "ἡ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "χάρις",
+          "strong": "G54850",
+          "x-morph": "Gr,N,,,,,NFS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/grace",
+          "content": [
+            "χάρις"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,GMS,",
+          "content": [
+            "τοῦ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "θεός",
+          "strong": "G23160",
+          "x-morph": "Gr,N,,,,,GMS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/god",
+          "content": [
+            "Θεοῦ"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "σωτήριος",
+          "strong": "G49920",
+          "x-morph": "Gr,NS,,,,NMS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/save",
+          "content": [
+            "σωτήριος"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πᾶς",
+          "strong": "G39560",
+          "x-morph": "Gr,EQ,,,,DMP,",
+          "content": [
+            "πᾶσιν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἄνθρωπος",
+          "strong": "G04440",
+          "x-morph": "Gr,N,,,,,DMP,",
+          "content": [
+            "ἀνθρώποις"
+          ]
+        },
+        ", ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "12",
+          "sid": "TIT 2:12"
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "παιδεύω",
+          "strong": "G38110",
+          "x-morph": "Gr,V,PPA,NFS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/discipline",
+          "content": [
+            "παιδεύουσα"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐγώ",
+          "strong": "G14730",
+          "x-morph": "Gr,RP,,,1A,P,",
+          "content": [
+            "ἡμᾶς"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἵνα",
+          "strong": "G24430",
+          "x-morph": "Gr,CS,,,,,,,,",
+          "content": [
+            "ἵνα"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀρνέομαι",
+          "strong": "G07200",
+          "x-morph": "Gr,V,PAM,NMP,",
+          "content": [
+            "ἀρνησάμενοι"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,AFS,",
+          "content": [
+            "τὴν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀσέβεια",
+          "strong": "G07630",
+          "x-morph": "Gr,N,,,,,AFS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/godly",
+          "content": [
+            "ἀσέβειαν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καί",
+          "strong": "G25320",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "καὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,AFP,",
+          "content": [
+            "τὰς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "κοσμικός",
+          "strong": "G28860",
+          "x-morph": "Gr,AA,,,,AFP,",
+          "x-tw": "rc://*/tw/dict/bible/kt/world",
+          "content": [
+            "κοσμικὰς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐπιθυμία",
+          "strong": "G19390",
+          "x-morph": "Gr,N,,,,,AFP,",
+          "x-tw": "rc://*/tw/dict/bible/other/lust",
+          "content": [
+            "ἐπιθυμίας"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "σωφρόνως",
+          "strong": "G49960",
+          "x-morph": "Gr,D,,,,,,,,,",
+          "content": [
+            "σωφρόνως"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καί",
+          "strong": "G25320",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "καὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "δικαίως",
+          "strong": "G13460",
+          "x-morph": "Gr,D,,,,,,,,,",
+          "x-tw": "rc://*/tw/dict/bible/kt/righteous",
+          "content": [
+            "δικαίως"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καί",
+          "strong": "G25320",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "καὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "εὐσεβῶς",
+          "strong": "G21530",
+          "x-morph": "Gr,D,,,,,,,,,",
+          "x-tw": "rc://*/tw/dict/bible/kt/godly",
+          "content": [
+            "εὐσεβῶς"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ζάω",
+          "strong": "G21980",
+          "x-morph": "Gr,V,SAA1,,P,",
+          "x-tw": "rc://*/tw/dict/bible/kt/life",
+          "content": [
+            "ζήσωμεν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐν",
+          "strong": "G17220",
+          "x-morph": "Gr,P,,,,,D,,,",
+          "content": [
+            "ἐν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,DMS,",
+          "content": [
+            "τῷ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "νῦν",
+          "strong": "G35680",
+          "x-morph": "Gr,D,,,,,,,,,",
+          "content": [
+            "νῦν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "αἰών",
+          "strong": "G01650",
+          "x-morph": "Gr,N,,,,,DMS,",
+          "x-tw": "rc://*/tw/dict/bible/other/age",
+          "content": [
+            "αἰῶνι"
+          ]
+        },
+        "; ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "13",
+          "sid": "TIT 2:13"
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "προσδέχομαι",
+          "strong": "G43270",
+          "x-morph": "Gr,V,PPM,NMP,",
+          "x-tw": "rc://*/tw/dict/bible/other/receive",
+          "content": [
+            "προσδεχόμενοι"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,AFS,",
+          "content": [
+            "τὴν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "μακάριος",
+          "strong": "G31070",
+          "x-morph": "Gr,AA,,,,AFS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/bless",
+          "content": [
+            "μακαρίαν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐλπίς",
+          "strong": "G16800",
+          "x-morph": "Gr,N,,,,,AFS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/hope",
+          "content": [
+            "ἐλπίδα"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καί",
+          "strong": "G25320",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "καὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐπιφάνεια",
+          "strong": "G20150",
+          "x-morph": "Gr,N,,,,,AFS,",
+          "content": [
+            "ἐπιφάνειαν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,GFS,",
+          "content": [
+            "τῆς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "δόξα",
+          "strong": "G13910",
+          "x-morph": "Gr,N,,,,,GFS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/glory",
+          "content": [
+            "δόξης"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,GMS,",
+          "content": [
+            "τοῦ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "μέγας",
+          "strong": "G31730",
+          "x-morph": "Gr,AA,,,,GMS,",
+          "content": [
+            "μεγάλου"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "θεός",
+          "strong": "G23160",
+          "x-morph": "Gr,N,,,,,GMS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/god",
+          "content": [
+            "Θεοῦ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καί",
+          "strong": "G25320",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "καὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "σωτήρ",
+          "strong": "G49900",
+          "x-morph": "Gr,N,,,,,GMS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/savior",
+          "content": [
+            "Σωτῆρος"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐγώ",
+          "strong": "G14730",
+          "x-morph": "Gr,RP,,,1G,P,",
+          "content": [
+            "ἡμῶν"
+          ]
+        },
+        ", \\k-s| x-tw=\"rc:",
+        {
+          "type": "optbreak"
+        },
+        "*/tw/dict/bible/kt/jesus\"\n",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "Ἰησοῦς",
+          "strong": "G24240",
+          "x-morph": "Gr,N,,,,,GMS,",
+          "content": [
+            "Ἰησοῦ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "χριστός",
+          "strong": "G55470",
+          "x-morph": "Gr,N,,,,,GMS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/christ",
+          "content": [
+            "Χριστοῦ"
+          ]
+        },
+        {
+          "type": "ms",
+          "marker": "k-e"
+        },
+        "; ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "14",
+          "sid": "TIT 2:14"
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὅς",
+          "strong": "G37390",
+          "x-morph": "Gr,RR,,,,NMS,",
+          "content": [
+            "ὃς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "δίδωμι",
+          "strong": "G13250",
+          "x-morph": "Gr,V,IAA3,,S,",
+          "content": [
+            "ἔδωκεν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἑαυτοῦ",
+          "strong": "G14380",
+          "x-morph": "Gr,RE,,,3AMS,",
+          "content": [
+            "ἑαυτὸν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὑπέρ",
+          "strong": "G52280",
+          "x-morph": "Gr,P,,,,,G,,,",
+          "content": [
+            "ὑπὲρ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐγώ",
+          "strong": "G14730",
+          "x-morph": "Gr,RP,,,1G,P,",
+          "content": [
+            "ἡμῶν"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἵνα",
+          "strong": "G24430",
+          "x-morph": "Gr,CS,,,,,,,,",
+          "content": [
+            "ἵνα"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "λυτρόω",
+          "strong": "G30840",
+          "x-morph": "Gr,V,SAM3,,S,",
+          "x-tw": "rc://*/tw/dict/bible/kt/redeem",
+          "content": [
+            "λυτρώσηται"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐγώ",
+          "strong": "G14730",
+          "x-morph": "Gr,RP,,,1A,P,",
+          "content": [
+            "ἡμᾶς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀπό",
+          "strong": "G05750",
+          "x-morph": "Gr,P,,,,,G,,,",
+          "content": [
+            "ἀπὸ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πᾶς",
+          "strong": "G39560",
+          "x-morph": "Gr,EQ,,,,GFS,",
+          "content": [
+            "πάσης"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀνομία",
+          "strong": "G04580",
+          "x-morph": "Gr,N,,,,,GFS,",
+          "x-tw": "rc://*/tw/dict/bible/other/lawful",
+          "content": [
+            "ἀνομίας"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καί",
+          "strong": "G25320",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "καὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καθαρίζω",
+          "strong": "G25110",
+          "x-morph": "Gr,V,SAA3,,S,",
+          "x-tw": "rc://*/tw/dict/bible/kt/clean",
+          "content": [
+            "καθαρίσῃ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἑαυτοῦ",
+          "strong": "G14380",
+          "x-morph": "Gr,RE,,,3DMS,",
+          "content": [
+            "ἑαυτῷ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "λαός",
+          "strong": "G29920",
+          "x-morph": "Gr,N,,,,,AMS,",
+          "x-tw": "rc://*/tw/dict/bible/other/peoplegroup",
+          "content": [
+            "λαὸν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "περιούσιος",
+          "strong": "G40410",
+          "x-morph": "Gr,AA,,,,AMS,",
+          "x-tw": "rc://*/tw/dict/bible/other/possess",
+          "content": [
+            "περιούσιον"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ζηλωτής",
+          "strong": "G22070",
+          "x-morph": "Gr,N,,,,,AMS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/zealous",
+          "content": [
+            "ζηλωτὴν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καλός",
+          "strong": "G25700",
+          "x-morph": "Gr,AA,,,,GNP,",
+          "x-tw": "rc://*/tw/dict/bible/kt/good",
+          "content": [
+            "καλῶν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἔργον",
+          "strong": "G20410",
+          "x-morph": "Gr,N,,,,,GNP,",
+          "x-tw": "rc://*/tw/dict/bible/kt/works",
+          "content": [
+            "ἔργων"
+          ]
+        },
+        ". ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "15",
+          "sid": "TIT 2:15"
+        }
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "οὗτος",
+          "strong": "G37780",
+          "x-morph": "Gr,RD,,,,ANP,",
+          "content": [
+            "ταῦτα"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "λαλέω",
+          "strong": "G29800",
+          "x-morph": "Gr,V,MPA2,,S,",
+          "content": [
+            "λάλει"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καί",
+          "strong": "G25320",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "καὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "παρακαλέω",
+          "strong": "G38700",
+          "x-morph": "Gr,V,MPA2,,S,",
+          "x-tw": "rc://*/tw/dict/bible/kt/exhort",
+          "content": [
+            "παρακάλει"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καί",
+          "strong": "G25320",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "καὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐλέγχω",
+          "strong": "G16510",
+          "x-morph": "Gr,V,MPA2,,S,",
+          "x-tw": "rc://*/tw/dict/bible/other/rebuke",
+          "content": [
+            "ἔλεγχε"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "μετά",
+          "strong": "G33260",
+          "x-morph": "Gr,P,,,,,G,,,",
+          "content": [
+            "μετὰ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πᾶς",
+          "strong": "G39560",
+          "x-morph": "Gr,EQ,,,,GFS,",
+          "content": [
+            "πάσης"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐπιταγή",
+          "strong": "G20030",
+          "x-morph": "Gr,N,,,,,GFS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/authority",
+          "content": [
+            "ἐπιταγῆς"
+          ]
+        },
+        ". ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "μηδείς",
+          "strong": "G33670",
+          "x-morph": "Gr,RI,,,,NMS,",
+          "content": [
+            "μηδείς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "σύ",
+          "strong": "G47710",
+          "x-morph": "Gr,RP,,,2G,S,",
+          "content": [
+            "σου"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "περιφρονέω",
+          "strong": "G40650",
+          "x-morph": "Gr,V,MPA3,,S,",
+          "content": [
+            "περιφρονείτω"
+          ]
+        },
+        "."
+      ]
+    },
+    {
+      "type": "chapter",
+      "marker": "c",
+      "number": "3",
+      "sid": "TIT 3"
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "1",
+          "sid": "TIT 3:1"
+        }
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὑπομιμνῄσκω",
+          "strong": "G52790",
+          "x-morph": "Gr,V,MPA2,,S,",
+          "content": [
+            "ὑπομίμνῃσκε"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "αὐτός",
+          "strong": "G08460",
+          "x-morph": "Gr,RP,,,3AMP,",
+          "content": [
+            "αὐτοὺς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀρχή",
+          "strong": "G07460",
+          "x-morph": "Gr,N,,,,,DFP,",
+          "x-tw": "rc://*/tw/dict/bible/other/ruler",
+          "content": [
+            "ἀρχαῖς"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐξουσία",
+          "strong": "G18490",
+          "x-morph": "Gr,N,,,,,DFP,",
+          "x-tw": "rc://*/tw/dict/bible/kt/authority",
+          "content": [
+            "ἐξουσίαις"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὑποτάσσω",
+          "strong": "G52930",
+          "x-morph": "Gr,V,NPM,,,,,",
+          "x-tw": "rc://*/tw/dict/bible/other/subject",
+          "content": [
+            "ὑποτάσσεσθαι"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πειθαρχέω",
+          "strong": "G39800",
+          "x-morph": "Gr,V,NPA,,,,,",
+          "x-tw": "rc://*/tw/dict/bible/other/obey",
+          "content": [
+            "πειθαρχεῖν"
+          ]
+        },
+        "; ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πρός",
+          "strong": "G43140",
+          "x-morph": "Gr,P,,,,,A,,,",
+          "content": [
+            "πρὸς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πᾶς",
+          "strong": "G39560",
+          "x-morph": "Gr,EQ,,,,ANS,",
+          "content": [
+            "πᾶν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἔργον",
+          "strong": "G20410",
+          "x-morph": "Gr,N,,,,,ANS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/works",
+          "content": [
+            "ἔργον"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀγαθός",
+          "strong": "G00180",
+          "x-morph": "Gr,AA,,,,ANS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/good",
+          "content": [
+            "ἀγαθὸν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἕτοιμος",
+          "strong": "G20920",
+          "x-morph": "Gr,NP,,,,AMP,",
+          "content": [
+            "ἑτοίμους"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "εἰμί",
+          "strong": "G15100",
+          "x-morph": "Gr,V,NPA,,,,,",
+          "content": [
+            "εἶναι"
+          ]
+        },
+        ", ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "2",
+          "sid": "TIT 3:2"
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "μηδείς",
+          "strong": "G33670",
+          "x-morph": "Gr,RI,,,,AMS,",
+          "content": [
+            "μηδένα"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "βλασφημέω",
+          "strong": "G09870",
+          "x-morph": "Gr,V,NPA,,,,,",
+          "x-tw": "rc://*/tw/dict/bible/kt/blasphemy",
+          "content": [
+            "βλασφημεῖν"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἄμαχος",
+          "strong": "G02690",
+          "x-morph": "Gr,NP,,,,AMP,",
+          "x-tw": "rc://*/tw/dict/bible/other/peace",
+          "content": [
+            "ἀμάχους"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "εἰμί",
+          "strong": "G15100",
+          "x-morph": "Gr,V,NPA,,,,,",
+          "content": [
+            "εἶναι"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐπιεικής",
+          "strong": "G19330",
+          "x-morph": "Gr,NP,,,,AMP,",
+          "content": [
+            "ἐπιεικεῖς"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πᾶς",
+          "strong": "G39560",
+          "x-morph": "Gr,EQ,,,,AFS,",
+          "content": [
+            "πᾶσαν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐνδείκνυμι",
+          "strong": "G17310",
+          "x-morph": "Gr,V,PPM,AMP,",
+          "content": [
+            "ἐνδεικνυμένους"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πραΰτης",
+          "strong": "G42400",
+          "x-morph": "Gr,N,,,,,AFS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/humble",
+          "content": [
+            "πραΰτητα"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πρός",
+          "strong": "G43140",
+          "x-morph": "Gr,P,,,,,A,,,",
+          "content": [
+            "πρὸς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πᾶς",
+          "strong": "G39560",
+          "x-morph": "Gr,EQ,,,,AMP,",
+          "content": [
+            "πάντας"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἄνθρωπος",
+          "strong": "G04440",
+          "x-morph": "Gr,N,,,,,AMP,",
+          "content": [
+            "ἀνθρώπους"
+          ]
+        },
+        ". ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "3",
+          "sid": "TIT 3:3"
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "εἰμί",
+          "strong": "G15100",
+          "x-morph": "Gr,V,IIA1,,P,",
+          "content": [
+            "ἦμεν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "γάρ",
+          "strong": "G10630",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "γάρ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ποτέ",
+          "strong": "G42180",
+          "x-morph": "Gr,D,,,,,,,,,",
+          "content": [
+            "ποτε"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καί",
+          "strong": "G25320",
+          "x-morph": "Gr,D,,,,,,,,,",
+          "content": [
+            "καὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐγώ",
+          "strong": "G14730",
+          "x-morph": "Gr,RP,,,1N,P,",
+          "content": [
+            "ἡμεῖς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀνόητος",
+          "strong": "G04530",
+          "x-morph": "Gr,NS,,,,NMP,",
+          "x-tw": "rc://*/tw/dict/bible/kt/foolish",
+          "content": [
+            "ἀνόητοι"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀπειθής",
+          "strong": "G05450",
+          "x-morph": "Gr,NS,,,,NMP,",
+          "x-tw": "rc://*/tw/dict/bible/other/disobey",
+          "content": [
+            "ἀπειθεῖς"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πλανάω",
+          "strong": "G41050",
+          "x-morph": "Gr,V,PPP,NMP,",
+          "x-tw": "rc://*/tw/dict/bible/other/astray",
+          "content": [
+            "πλανώμενοι"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "δουλεύω",
+          "strong": "G13980",
+          "x-morph": "Gr,V,PPA,NMP,",
+          "x-tw": "rc://*/tw/dict/bible/other/enslave",
+          "content": [
+            "δουλεύοντες"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐπιθυμία",
+          "strong": "G19390",
+          "x-morph": "Gr,N,,,,,DFP,",
+          "x-tw": "rc://*/tw/dict/bible/other/lust",
+          "content": [
+            "ἐπιθυμίαις"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καί",
+          "strong": "G25320",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "καὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἡδονή",
+          "strong": "G22370",
+          "x-morph": "Gr,N,,,,,DFP,",
+          "content": [
+            "ἡδοναῖς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ποικίλος",
+          "strong": "G41640",
+          "x-morph": "Gr,AA,,,,DFP,",
+          "content": [
+            "ποικίλαις"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐν",
+          "strong": "G17220",
+          "x-morph": "Gr,P,,,,,D,,,",
+          "content": [
+            "ἐν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "κακία",
+          "strong": "G25490",
+          "x-morph": "Gr,N,,,,,DFS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/evil",
+          "content": [
+            "κακίᾳ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καί",
+          "strong": "G25320",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "καὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "φθόνος",
+          "strong": "G53550",
+          "x-morph": "Gr,N,,,,,DMS,",
+          "x-tw": "rc://*/tw/dict/bible/other/envy",
+          "content": [
+            "φθόνῳ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "διάγω",
+          "strong": "G12360",
+          "x-morph": "Gr,V,PPA,NMP,",
+          "x-tw": "rc://*/tw/dict/bible/kt/live",
+          "content": [
+            "διάγοντες"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "στυγητός",
+          "strong": "G47670",
+          "x-morph": "Gr,NS,,,,NMP,",
+          "content": [
+            "στυγητοί"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "μισέω",
+          "strong": "G34040",
+          "x-morph": "Gr,V,PPA,NMP,",
+          "content": [
+            "μισοῦντες"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀλλήλων",
+          "strong": "G02400",
+          "x-morph": "Gr,RC,,,,AMP,",
+          "content": [
+            "ἀλλήλους"
+          ]
+        },
+        ". ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "4",
+          "sid": "TIT 3:4"
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὅτε",
+          "strong": "G37530",
+          "x-morph": "Gr,CS,,,,,,,,",
+          "content": [
+            "ὅτε"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "δέ",
+          "strong": "G11610",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "δὲ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,NFS,",
+          "content": [
+            "ἡ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "χρηστότης",
+          "strong": "G55440",
+          "x-morph": "Gr,N,,,,,NFS,",
+          "x-tw": "rc://*/tw/dict/bible/other/kind",
+          "content": [
+            "χρηστότης"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καί",
+          "strong": "G25320",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "καὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,NFS,",
+          "content": [
+            "ἡ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "φιλανθρωπία",
+          "strong": "G53630",
+          "x-morph": "Gr,N,,,,,NFS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/love",
+          "content": [
+            "φιλανθρωπία"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐπιφαίνω",
+          "strong": "G20140",
+          "x-morph": "Gr,V,IAP3,,S,",
+          "content": [
+            "ἐπεφάνη"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,GMS,",
+          "content": [
+            "τοῦ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "σωτήρ",
+          "strong": "G49900",
+          "x-morph": "Gr,N,,,,,GMS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/savior",
+          "content": [
+            "Σωτῆρος"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐγώ",
+          "strong": "G14730",
+          "x-morph": "Gr,RP,,,1G,P,",
+          "content": [
+            "ἡμῶν"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "θεός",
+          "strong": "G23160",
+          "x-morph": "Gr,N,,,,,GMS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/god",
+          "content": [
+            "Θεοῦ"
+          ]
+        },
+        ", ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "5",
+          "sid": "TIT 3:5"
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "οὐ",
+          "strong": "G37560",
+          "x-morph": "Gr,DO,,,,,,,,",
+          "content": [
+            "οὐκ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐκ",
+          "strong": "G15370",
+          "x-morph": "Gr,P,,,,,G,,,",
+          "content": [
+            "ἐξ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἔργον",
+          "strong": "G20410",
+          "x-morph": "Gr,N,,,,,GNP,",
+          "x-tw": "rc://*/tw/dict/bible/kt/works",
+          "content": [
+            "ἔργων"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,RD,,,,GNP,",
+          "content": [
+            "τῶν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐν",
+          "strong": "G17220",
+          "x-morph": "Gr,P,,,,,D,,,",
+          "content": [
+            "ἐν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "δικαιοσύνη",
+          "strong": "G13430",
+          "x-morph": "Gr,N,,,,,DFS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/righteous",
+          "content": [
+            "δικαιοσύνῃ"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὅς",
+          "strong": "G37390",
+          "x-morph": "Gr,RD,,,,ANP,",
+          "content": [
+            "ἃ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ποιέω",
+          "strong": "G41600",
+          "x-morph": "Gr,V,IAA1,,P,",
+          "content": [
+            "ἐποιήσαμεν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐγώ",
+          "strong": "G14730",
+          "x-morph": "Gr,RP,,,1N,P,",
+          "content": [
+            "ἡμεῖς"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀλλά",
+          "strong": "G02350",
+          "x-morph": "Gr,CO,,,,,,,,",
+          "content": [
+            "ἀλλὰ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "κατά",
+          "strong": "G25960",
+          "x-morph": "Gr,P,,,,,A,,,",
+          "content": [
+            "κατὰ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,ANS,",
+          "content": [
+            "τὸ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "αὐτός",
+          "strong": "G08460",
+          "x-morph": "Gr,RP,,,3GMS,",
+          "content": [
+            "αὐτοῦ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἔλεος",
+          "strong": "G16560",
+          "x-morph": "Gr,N,,,,,ANS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/mercy",
+          "content": [
+            "ἔλεος"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "σῴζω",
+          "strong": "G49820",
+          "x-morph": "Gr,V,IAA3,,S,",
+          "x-tw": "rc://*/tw/dict/bible/kt/save",
+          "content": [
+            "ἔσωσεν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐγώ",
+          "strong": "G14730",
+          "x-morph": "Gr,RP,,,1A,P,",
+          "content": [
+            "ἡμᾶς"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "διά",
+          "strong": "G12230",
+          "x-morph": "Gr,P,,,,,G,,,",
+          "content": [
+            "διὰ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "λουτρόν",
+          "strong": "G30670",
+          "x-morph": "Gr,N,,,,,GNS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/clean",
+          "content": [
+            "λουτροῦ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "παλινγενεσία",
+          "strong": "G38240",
+          "x-morph": "Gr,N,,,,,GFS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/bornagain",
+          "content": [
+            "παλινγενεσίας"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καί",
+          "strong": "G25320",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "καὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀνακαίνωσις",
+          "strong": "G03420",
+          "x-morph": "Gr,N,,,,,GFS,",
+          "content": [
+            "ἀνακαινώσεως"
+          ]
+        },
+        " \\k-s| x-tw=\"rc:",
+        {
+          "type": "optbreak"
+        },
+        "*/tw/dict/bible/kt/holyspirit\"\n",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πνεῦμα",
+          "strong": "G41510",
+          "x-morph": "Gr,N,,,,,GNS,",
+          "content": [
+            "Πνεύματος"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἅγιος",
+          "strong": "G00400",
+          "x-morph": "Gr,AA,,,,GNS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/holy",
+          "content": [
+            "Ἁγίου"
+          ]
+        },
+        {
+          "type": "ms",
+          "marker": "k-e"
+        },
+        ", ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "6",
+          "sid": "TIT 3:6"
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὅς",
+          "strong": "G37390",
+          "x-morph": "Gr,RR,,,,GNS,",
+          "content": [
+            "οὗ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐκχέω",
+          "strong": "G16320",
+          "x-morph": "Gr,V,IAA3,,S,",
+          "content": [
+            "ἐξέχεεν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐπί",
+          "strong": "G19090",
+          "x-morph": "Gr,P,,,,,A,,,",
+          "content": [
+            "ἐφ’"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐγώ",
+          "strong": "G14730",
+          "x-morph": "Gr,RP,,,1A,P,",
+          "content": [
+            "ἡμᾶς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πλουσίως",
+          "strong": "G41460",
+          "x-morph": "Gr,D,,,,,,,,,",
+          "content": [
+            "πλουσίως"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "διά",
+          "strong": "G12230",
+          "x-morph": "Gr,P,,,,,G,,,",
+          "content": [
+            "διὰ"
+          ]
+        },
+        " \\k-s| x-tw=\"rc:",
+        {
+          "type": "optbreak"
+        },
+        "*/tw/dict/bible/kt/jesus\"\n",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "Ἰησοῦς",
+          "strong": "G24240",
+          "x-morph": "Gr,N,,,,,GMS,",
+          "content": [
+            "Ἰησοῦ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "χριστός",
+          "strong": "G55470",
+          "x-morph": "Gr,N,,,,,GMS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/christ",
+          "content": [
+            "Χριστοῦ"
+          ]
+        },
+        {
+          "type": "ms",
+          "marker": "k-e"
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,GMS,",
+          "content": [
+            "τοῦ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "σωτήρ",
+          "strong": "G49900",
+          "x-morph": "Gr,N,,,,,GMS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/savior",
+          "content": [
+            "Σωτῆρος"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐγώ",
+          "strong": "G14730",
+          "x-morph": "Gr,RP,,,1G,P,",
+          "content": [
+            "ἡμῶν"
+          ]
+        },
+        ", ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "7",
+          "sid": "TIT 3:7"
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἵνα",
+          "strong": "G24430",
+          "x-morph": "Gr,CS,,,,,,,,",
+          "content": [
+            "ἵνα"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "δικαιόω",
+          "strong": "G13440",
+          "x-morph": "Gr,V,PAP,NMP,",
+          "x-tw": "rc://*/tw/dict/bible/kt/justice",
+          "content": [
+            "δικαιωθέντες"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,DFS,",
+          "content": [
+            "τῇ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐκεῖνος",
+          "strong": "G15650",
+          "x-morph": "Gr,RD,,,,GMS,",
+          "content": [
+            "ἐκείνου"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "χάρις",
+          "strong": "G54850",
+          "x-morph": "Gr,N,,,,,DFS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/grace",
+          "content": [
+            "χάριτι"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "κληρονόμος",
+          "strong": "G28180",
+          "x-morph": "Gr,N,,,,,NMP,",
+          "x-tw": "rc://*/tw/dict/bible/other/heir",
+          "content": [
+            "κληρονόμοι"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "γίνομαι",
+          "strong": "G10960",
+          "x-morph": "Gr,V,SAP1,,P,",
+          "content": [
+            "γενηθῶμεν"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "κατά",
+          "strong": "G25960",
+          "x-morph": "Gr,P,,,,,A,,,",
+          "content": [
+            "κατ’"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐλπίς",
+          "strong": "G16800",
+          "x-morph": "Gr,N,,,,,AFS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/hope",
+          "content": [
+            "ἐλπίδα"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ζωή",
+          "strong": "G22220",
+          "x-morph": "Gr,N,,,,,GFS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/life",
+          "content": [
+            "ζωῆς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "αἰώνιος",
+          "strong": "G01660",
+          "x-morph": "Gr,AA,,,,GFS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/eternity",
+          "content": [
+            "αἰωνίου"
+          ]
+        },
+        ". ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "8",
+          "sid": "TIT 3:8"
+        }
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πιστός",
+          "strong": "G41030",
+          "x-morph": "Gr,NP,,,,NMS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/faithful",
+          "content": [
+            "πιστὸς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,NMS,",
+          "content": [
+            "ὁ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "λόγος",
+          "strong": "G30560",
+          "x-morph": "Gr,N,,,,,NMS,",
+          "x-tw": "rc://*/tw/dict/bible/other/word",
+          "content": [
+            "λόγος"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καί",
+          "strong": "G25320",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "καὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "περί",
+          "strong": "G40120",
+          "x-morph": "Gr,P,,,,,G,,,",
+          "content": [
+            "περὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "οὗτος",
+          "strong": "G37780",
+          "x-morph": "Gr,RD,,,,GNP,",
+          "content": [
+            "τούτων"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "βούλομαι",
+          "strong": "G10140",
+          "x-morph": "Gr,V,IPM1,,S,",
+          "content": [
+            "βούλομαί"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "σύ",
+          "strong": "G47710",
+          "x-morph": "Gr,RP,,,2A,S,",
+          "content": [
+            "σε"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "διαβεβαιόομαι",
+          "strong": "G12260",
+          "x-morph": "Gr,V,NPM,,,,,",
+          "content": [
+            "διαβεβαιοῦσθαι"
+          ]
+        },
+        ", “",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἵνα",
+          "strong": "G24430",
+          "x-morph": "Gr,CS,,,,,,,,",
+          "content": [
+            "ἵνα"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "φροντίζω",
+          "strong": "G54310",
+          "x-morph": "Gr,V,SPA3,,P,",
+          "content": [
+            "φροντίζωσιν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καλός",
+          "strong": "G25700",
+          "x-morph": "Gr,AA,,,,GNP,",
+          "x-tw": "rc://*/tw/dict/bible/kt/good",
+          "content": [
+            "καλῶν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἔργον",
+          "strong": "G20410",
+          "x-morph": "Gr,N,,,,,GNP,",
+          "x-tw": "rc://*/tw/dict/bible/kt/works",
+          "content": [
+            "ἔργων"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "προΐστημι",
+          "strong": "G42910",
+          "x-morph": "Gr,V,NPM,,,,,",
+          "x-tw": "rc://*/tw/dict/bible/other/manager",
+          "content": [
+            "προΐστασθαι"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,RD,,,,NMP,",
+          "content": [
+            "οἱ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πιστεύω",
+          "strong": "G41000",
+          "x-morph": "Gr,V,PEA,NMP,",
+          "x-tw": "rc://*/tw/dict/bible/kt/believe",
+          "content": [
+            "πεπιστευκότες"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "θεός",
+          "strong": "G23160",
+          "x-morph": "Gr,N,,,,,DMS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/god",
+          "content": [
+            "Θεῷ"
+          ]
+        },
+        ".” ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "οὗτος",
+          "strong": "G37780",
+          "x-morph": "Gr,RD,,,,NNP,",
+          "content": [
+            "ταῦτά"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "εἰμί",
+          "strong": "G15100",
+          "x-morph": "Gr,V,IPA3,,S,",
+          "content": [
+            "ἐστιν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καλός",
+          "strong": "G25700",
+          "x-morph": "Gr,NP,,,,NNP,",
+          "x-tw": "rc://*/tw/dict/bible/kt/good",
+          "content": [
+            "καλὰ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καί",
+          "strong": "G25320",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "καὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὠφέλιμος",
+          "strong": "G56240",
+          "x-morph": "Gr,NP,,,,NNP,",
+          "x-tw": "rc://*/tw/dict/bible/other/profit",
+          "content": [
+            "ὠφέλιμα"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,DMP,",
+          "content": [
+            "τοῖς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἄνθρωπος",
+          "strong": "G04440",
+          "x-morph": "Gr,N,,,,,DMP,",
+          "content": [
+            "ἀνθρώποις"
+          ]
+        },
+        ". ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "9",
+          "sid": "TIT 3:9"
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "μωρός",
+          "strong": "G34740",
+          "x-morph": "Gr,AA,,,,AFP,",
+          "x-tw": "rc://*/tw/dict/bible/kt/foolish",
+          "content": [
+            "μωρὰς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "δέ",
+          "strong": "G11610",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "δὲ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ζήτησις",
+          "strong": "G22140",
+          "x-morph": "Gr,N,,,,,AFP,",
+          "content": [
+            "ζητήσεις"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καί",
+          "strong": "G25320",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "καὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "γενεαλογία",
+          "strong": "G10760",
+          "x-morph": "Gr,N,,,,,AFP,",
+          "content": [
+            "γενεαλογίας"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καί",
+          "strong": "G25320",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "καὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἔρις",
+          "strong": "G20540",
+          "x-morph": "Gr,N,,,,,AFP,",
+          "x-tw": "rc://*/tw/dict/bible/other/strife",
+          "content": [
+            "ἔρεις"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καί",
+          "strong": "G25320",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "καὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "μάχη",
+          "strong": "G31630",
+          "x-morph": "Gr,N,,,,,AFP,",
+          "x-tw": "rc://*/tw/dict/bible/other/strife",
+          "content": [
+            "μάχας"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "νομικός",
+          "strong": "G35440",
+          "x-morph": "Gr,AA,,,,AFP,",
+          "x-tw": "rc://*/tw/dict/bible/kt/lawofmoses",
+          "content": [
+            "νομικὰς"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "περιΐστημι",
+          "strong": "G40260",
+          "x-morph": "Gr,V,MPM2,,S,",
+          "content": [
+            "περιΐστασο"
+          ]
+        },
+        "; ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "εἰμί",
+          "strong": "G15100",
+          "x-morph": "Gr,V,IPA3,,P,",
+          "content": [
+            "εἰσὶν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "γάρ",
+          "strong": "G10630",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "γὰρ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀνωφελής",
+          "strong": "G05120",
+          "x-morph": "Gr,NS,,,,NFP,",
+          "content": [
+            "ἀνωφελεῖς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καί",
+          "strong": "G25320",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "καὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "μάταιος",
+          "strong": "G31520",
+          "x-morph": "Gr,NS,,,,NFP,",
+          "x-tw": "rc://*/tw/dict/bible/other/vain",
+          "content": [
+            "μάταιοι"
+          ]
+        },
+        ". ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "10",
+          "sid": "TIT 3:10"
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "αἱρετικός",
+          "strong": "G01410",
+          "x-morph": "Gr,AA,,,,AMS,",
+          "content": [
+            "αἱρετικὸν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἄνθρωπος",
+          "strong": "G04440",
+          "x-morph": "Gr,N,,,,,AMS,",
+          "content": [
+            "ἄνθρωπον"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "μετά",
+          "strong": "G33260",
+          "x-morph": "Gr,P,,,,,A,,,",
+          "content": [
+            "μετὰ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "εἷς",
+          "strong": "G15200",
+          "x-morph": "Gr,EN,,,,AFS,",
+          "content": [
+            "μίαν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καί",
+          "strong": "G25320",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "καὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "δεύτερος",
+          "strong": "G12080",
+          "x-morph": "Gr,EO,,,,AFS,",
+          "content": [
+            "δευτέραν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "νουθεσία",
+          "strong": "G35590",
+          "x-morph": "Gr,N,,,,,AFS,",
+          "x-tw": "rc://*/tw/dict/bible/other/admonish",
+          "content": [
+            "νουθεσίαν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "παραιτέομαι",
+          "strong": "G38680",
+          "x-morph": "Gr,V,MPM2,,S,",
+          "x-tw": "rc://*/tw/dict/bible/other/reject",
+          "content": [
+            "παραιτοῦ"
+          ]
+        },
+        ", ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "11",
+          "sid": "TIT 3:11"
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "εἴδω",
+          "strong": "G14920",
+          "x-morph": "Gr,V,PEA,NMS,",
+          "x-tw": "rc://*/tw/dict/bible/other/know",
+          "content": [
+            "εἰδὼς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὅτι",
+          "strong": "G37540",
+          "x-morph": "Gr,CS,,,,,,,,",
+          "content": [
+            "ὅτι"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐκστρέφω",
+          "strong": "G16120",
+          "x-morph": "Gr,V,IEP3,,S,",
+          "x-tw": "rc://*/tw/dict/bible/other/perverse",
+          "content": [
+            "ἐξέστραπται"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,NMS,",
+          "content": [
+            "ὁ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "τοιοῦτος",
+          "strong": "G51080",
+          "x-morph": "Gr,RD,,,,NMS,",
+          "content": [
+            "τοιοῦτος"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καί",
+          "strong": "G25320",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "καὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἁμαρτάνω",
+          "strong": "G02640",
+          "x-morph": "Gr,V,IPA3,,S,",
+          "x-tw": "rc://*/tw/dict/bible/kt/sin",
+          "content": [
+            "ἁμαρτάνει"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "εἰμί",
+          "strong": "G15100",
+          "x-morph": "Gr,V,PPA,NMS,",
+          "content": [
+            "ὢν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "αὐτοκατάκριτος",
+          "strong": "G08430",
+          "x-morph": "Gr,NP,,,,NMS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/condemn",
+          "content": [
+            "αὐτοκατάκριτος"
+          ]
+        },
+        ". ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "12",
+          "sid": "TIT 3:12"
+        }
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὅταν",
+          "strong": "G37520",
+          "x-morph": "Gr,CS,,,,,,,,",
+          "content": [
+            "ὅταν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πέμπω",
+          "strong": "G39920",
+          "x-morph": "Gr,V,SAA1,,S,",
+          "x-tw": "rc://*/tw/dict/bible/other/send",
+          "content": [
+            "πέμψω"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "Ἀρτεμᾶς",
+          "strong": "G07340",
+          "x-morph": "Gr,N,,,,,AMS,",
+          "content": [
+            "Ἀρτεμᾶν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πρός",
+          "strong": "G43140",
+          "x-morph": "Gr,P,,,,,A,,,",
+          "content": [
+            "πρὸς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "σύ",
+          "strong": "G47710",
+          "x-morph": "Gr,RP,,,2A,S,",
+          "content": [
+            "σὲ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἤ",
+          "strong": "G22280",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "ἢ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "Τυχικός",
+          "strong": "G51900",
+          "x-morph": "Gr,N,,,,,AMS,",
+          "x-tw": "rc://*/tw/dict/bible/names/tychicus",
+          "content": [
+            "Τυχικόν"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "σπουδάζω",
+          "strong": "G47040",
+          "x-morph": "Gr,V,MAA2,,S,",
+          "content": [
+            "σπούδασον"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἔρχομαι",
+          "strong": "G20640",
+          "x-morph": "Gr,V,NAA,,,,,",
+          "content": [
+            "ἐλθεῖν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πρός",
+          "strong": "G43140",
+          "x-morph": "Gr,P,,,,,A,,,",
+          "content": [
+            "πρός"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐγώ",
+          "strong": "G14730",
+          "x-morph": "Gr,RP,,,1A,S,",
+          "content": [
+            "με"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "εἰς",
+          "strong": "G15190",
+          "x-morph": "Gr,P,,,,,A,,,",
+          "content": [
+            "εἰς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "Νικόπολις",
+          "strong": "G35330",
+          "x-morph": "Gr,N,,,,,AFS,",
+          "content": [
+            "Νικόπολιν"
+          ]
+        },
+        "; ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐκεῖ",
+          "strong": "G15630",
+          "x-morph": "Gr,D,,,,,,,,,",
+          "content": [
+            "ἐκεῖ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "γάρ",
+          "strong": "G10630",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "γὰρ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "κρίνω",
+          "strong": "G29190",
+          "x-morph": "Gr,V,IEA1,,S,",
+          "content": [
+            "κέκρικα"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "παραχειμάζω",
+          "strong": "G39140",
+          "x-morph": "Gr,V,NAA,,,,,",
+          "content": [
+            "παραχειμάσαι"
+          ]
+        },
+        ". ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "13",
+          "sid": "TIT 3:13"
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "Ζηνᾶς",
+          "strong": "G22110",
+          "x-morph": "Gr,N,,,,,AMS,",
+          "content": [
+            "Ζηνᾶν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,AMS,",
+          "content": [
+            "τὸν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "νομικός",
+          "strong": "G35440",
+          "x-morph": "Gr,AR,,,,AMS,",
+          "x-tw": "rc://*/tw/dict/bible/other/law",
+          "content": [
+            "νομικὸν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καί",
+          "strong": "G25320",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "καὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "Ἀπολλῶς",
+          "strong": "G06250",
+          "x-morph": "Gr,N,,,,,AMS,",
+          "x-tw": "rc://*/tw/dict/bible/names/apollos",
+          "content": [
+            "Ἀπολλῶν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "σπουδαίως",
+          "strong": "G47090",
+          "x-morph": "Gr,D,,,,,,,,,",
+          "content": [
+            "σπουδαίως"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "προπέμπω",
+          "strong": "G43110",
+          "x-morph": "Gr,V,MAA2,,S,",
+          "x-tw": "rc://*/tw/dict/bible/other/send",
+          "content": [
+            "πρόπεμψον"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἵνα",
+          "strong": "G24430",
+          "x-morph": "Gr,CS,,,,,,,,",
+          "content": [
+            "ἵνα"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "μηδείς",
+          "strong": "G33670",
+          "x-morph": "Gr,RI,,,,NNS,",
+          "content": [
+            "μηδὲν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "αὐτός",
+          "strong": "G08460",
+          "x-morph": "Gr,RP,,,3DMP,",
+          "content": [
+            "αὐτοῖς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "λείπω",
+          "strong": "G30070",
+          "x-morph": "Gr,V,SPA3,,S,",
+          "content": [
+            "λείπῃ"
+          ]
+        },
+        ". ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "14",
+          "sid": "TIT 3:14"
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "μανθάνω",
+          "strong": "G31290",
+          "x-morph": "Gr,V,MPA3,,P,",
+          "content": [
+            "μανθανέτωσαν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "δέ",
+          "strong": "G11610",
+          "x-morph": "Gr,CC,,,,,,,,",
+          "content": [
+            "δὲ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καί",
+          "strong": "G25320",
+          "x-morph": "Gr,D,,,,,,,,,",
+          "content": [
+            "καὶ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,NMP,",
+          "content": [
+            "οἱ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἡμέτερος",
+          "strong": "G22510",
+          "x-morph": "Gr,RP,,,1NMP,",
+          "content": [
+            "ἡμέτεροι"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "καλός",
+          "strong": "G25700",
+          "x-morph": "Gr,AA,,,,GNP,",
+          "x-tw": "rc://*/tw/dict/bible/kt/good",
+          "content": [
+            "καλῶν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἔργον",
+          "strong": "G20410",
+          "x-morph": "Gr,N,,,,,GNP,",
+          "x-tw": "rc://*/tw/dict/bible/kt/works",
+          "content": [
+            "ἔργων"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "προΐστημι",
+          "strong": "G42910",
+          "x-morph": "Gr,V,NPM,,,,,",
+          "x-tw": "rc://*/tw/dict/bible/other/manager",
+          "content": [
+            "προΐστασθαι"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "εἰς",
+          "strong": "G15190",
+          "x-morph": "Gr,P,,,,,A,,,",
+          "content": [
+            "εἰς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,AFP,",
+          "content": [
+            "τὰς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀναγκαῖος",
+          "strong": "G03160",
+          "x-morph": "Gr,AA,,,,AFP,",
+          "content": [
+            "ἀναγκαίας"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "χρεία",
+          "strong": "G55320",
+          "x-morph": "Gr,N,,,,,AFP,",
+          "content": [
+            "χρείας"
+          ]
+        },
+        ", ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἵνα",
+          "strong": "G24430",
+          "x-morph": "Gr,CS,,,,,,,,",
+          "content": [
+            "ἵνα"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "μή",
+          "strong": "G33610",
+          "x-morph": "Gr,D,,,,,,,,,",
+          "content": [
+            "μὴ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "εἰμί",
+          "strong": "G15100",
+          "x-morph": "Gr,V,SPA3,,P,",
+          "content": [
+            "ὦσιν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἄκαρπος",
+          "strong": "G01750",
+          "x-morph": "Gr,NP,,,,NMP,",
+          "x-tw": "rc://*/tw/dict/bible/other/fruit",
+          "content": [
+            "ἄκαρποι"
+          ]
+        },
+        ". ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "15",
+          "sid": "TIT 3:15"
+        }
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀσπάζομαι",
+          "strong": "G07820",
+          "x-morph": "Gr,V,IPM3,,P,",
+          "content": [
+            "ἀσπάζονταί"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "σύ",
+          "strong": "G47710",
+          "x-morph": "Gr,RP,,,2A,S,",
+          "content": [
+            "σε"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,RD,,,,NMP,",
+          "content": [
+            "οἱ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "μετά",
+          "strong": "G33260",
+          "x-morph": "Gr,P,,,,,G,,,",
+          "content": [
+            "μετ’"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐγώ",
+          "strong": "G14730",
+          "x-morph": "Gr,RP,,,1G,S,",
+          "content": [
+            "ἐμοῦ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πᾶς",
+          "strong": "G39560",
+          "x-morph": "Gr,RI,,,,NMP,",
+          "content": [
+            "πάντες"
+          ]
+        },
+        ". ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἀσπάζομαι",
+          "strong": "G07820",
+          "x-morph": "Gr,V,MAM2,,S,",
+          "content": [
+            "ἄσπασαι"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,RD,,,,AMP,",
+          "content": [
+            "τοὺς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "φιλέω",
+          "strong": "G53680",
+          "x-morph": "Gr,V,PPA,AMP,",
+          "x-tw": "rc://*/tw/dict/bible/kt/love",
+          "content": [
+            "φιλοῦντας"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐγώ",
+          "strong": "G14730",
+          "x-morph": "Gr,RP,,,1A,P,",
+          "content": [
+            "ἡμᾶς"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ἐν",
+          "strong": "G17220",
+          "x-morph": "Gr,P,,,,,D,,,",
+          "content": [
+            "ἐν"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πίστις",
+          "strong": "G41020",
+          "x-morph": "Gr,N,,,,,DFS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/faith",
+          "content": [
+            "πίστει"
+          ]
+        },
+        ". ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "ὁ",
+          "strong": "G35880",
+          "x-morph": "Gr,EA,,,,NFS,",
+          "content": [
+            "ἡ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "χάρις",
+          "strong": "G54850",
+          "x-morph": "Gr,N,,,,,NFS,",
+          "x-tw": "rc://*/tw/dict/bible/kt/grace",
+          "content": [
+            "χάρις"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "μετά",
+          "strong": "G33260",
+          "x-morph": "Gr,P,,,,,G,,,",
+          "content": [
+            "μετὰ"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "πᾶς",
+          "strong": "G39560",
+          "x-morph": "Gr,RI,,,,GMP,",
+          "content": [
+            "πάντων"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "σύ",
+          "strong": "G47710",
+          "x-morph": "Gr,RP,,,2G,P,",
+          "content": [
+            "ὑμῶν"
+          ]
+        },
+        "."
+      ]
+    }
+  ]
+}

--- a/tests/usfmjsTests/57-TIT.greek/origin.json
+++ b/tests/usfmjsTests/57-TIT.greek/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",
@@ -8,13 +8,6 @@
       "code": "TIT",
       "content": [
         "Titus"
-      ]
-    },
-    {
-      "type": "para",
-      "marker": "usfm",
-      "content": [
-        "3.0"
       ]
     },
     {

--- a/tests/usfmjsTests/57-TIT.partial/origin.json
+++ b/tests/usfmjsTests/57-TIT.partial/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",
@@ -8,13 +8,6 @@
       "code": "TIT",
       "content": [
         "EN_ULT es_español_ltr Mon Mar 26 2018 11:44:25 GMT-0400 (EDT) tc"
-      ]
-    },
-    {
-      "type": "para",
-      "marker": "usfm",
-      "content": [
-        "3.0"
       ]
     },
     {

--- a/tests/usfmjsTests/acts-1-20.aligned/origin.json
+++ b/tests/usfmjsTests/acts-1-20.aligned/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",
@@ -8,13 +8,6 @@
       "code": "ACT",
       "content": [
         "EN_ULT en_English_ltr Wed Oct 10 2018 11:55:23 GMT-0400 (EDT) tc"
-      ]
-    },
-    {
-      "type": "para",
-      "marker": "usfm",
-      "content": [
-        "3.0"
       ]
     },
     {

--- a/tests/usfmjsTests/acts_1_11.aligned/origin.json
+++ b/tests/usfmjsTests/acts_1_11.aligned/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",
@@ -8,13 +8,6 @@
       "code": "ACT",
       "content": [
         "EN_ULT en_English_ltr Wed Oct 10 2018 11:55:23 GMT-0400 (EDT) tc"
-      ]
-    },
-    {
-      "type": "para",
-      "marker": "usfm",
-      "content": [
-        "3.0"
       ]
     },
     {

--- a/tests/usfmjsTests/acts_1_11/origin.json
+++ b/tests/usfmjsTests/acts_1_11/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/acts_1_4.aligned/origin.json
+++ b/tests/usfmjsTests/acts_1_4.aligned/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",
@@ -8,13 +8,6 @@
       "code": "ACT",
       "content": [
         "EN_ULT en_English_ltr Wed Oct 10 2018 11:55:23 GMT-0400 (EDT) tc"
-      ]
-    },
-    {
-      "type": "para",
-      "marker": "usfm",
-      "content": [
-        "3.0"
       ]
     },
     {

--- a/tests/usfmjsTests/acts_1_4/origin.json
+++ b/tests/usfmjsTests/acts_1_4/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/acts_1_milestone/origin.json
+++ b/tests/usfmjsTests/acts_1_milestone/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",
@@ -8,13 +8,6 @@
       "code": "ACT",
       "content": [
         "EN_ULT en_English_ltr Wed Oct 10 2018 11:55:23 GMT-0400 (EDT) tc"
-      ]
-    },
-    {
-      "type": "para",
-      "marker": "usfm",
-      "content": [
-        "3.0"
       ]
     },
     {

--- a/tests/usfmjsTests/acts_8-37-ugnt-footnote/origin.json
+++ b/tests/usfmjsTests/acts_8-37-ugnt-footnote/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/chunk/origin.json
+++ b/tests/usfmjsTests/chunk/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/chunk_footnote/origin.json
+++ b/tests/usfmjsTests/chunk_footnote/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/esb/origin.json
+++ b/tests/usfmjsTests/esb/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/f10_gen12-2_empty_word/origin.json
+++ b/tests/usfmjsTests/f10_gen12-2_empty_word/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/gn_headers/origin.json
+++ b/tests/usfmjsTests/gn_headers/origin.json
@@ -1,0 +1,562 @@
+{
+  "type": "USJ",
+  "version": "3.1",
+  "content": [
+    {
+      "type": "book",
+      "marker": "id",
+      "code": "TIT",
+      "content": [
+        "41MATGNT92.SFM, Good News Translation, June 2003"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ide",
+      "content": [
+        "UTF-8"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ide",
+      "content": [
+        "CP-1252"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ide",
+      "content": [
+        "Custom (TGUARANI.TTF)"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "sts",
+      "content": [
+        "2"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "rem",
+      "content": [
+        "Assigned to <translator's name>."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "rem",
+      "content": [
+        "First draft complete, waiting for checks."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "h",
+      "content": [
+        "Matthew"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "toc1",
+      "content": [
+        "The Gospel According to Matthew"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "toc2",
+      "content": [
+        "Matthew"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "toc3",
+      "content": [
+        "Mat"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "mt1",
+      "content": [
+        "THE ACTS"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "mt2",
+      "content": [
+        "of the Apostles"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "imt1",
+      "content": [
+        "INTRODUCCIÓN"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "is1",
+      "content": [
+        "Importancia del evangelio de Marcos"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ip",
+      "content": [
+        "The following lists summarize each Christian tradition’s views of the books here designated as Deuterocanonicals/Apocrypha."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ipi",
+      "content": [
+        "Many Protestants consider the following books to be Apocrypha as defined above: Tobit, Judith, additions to Esther (as found in Greek Esther in the CEV) ..."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ipi",
+      "content": [
+        "Roman Catholics consider the following books to be Deuterocanonical and of equal status with all other books of the Old Testament: Tobit, Judith, Greek Esther ..."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "imt1",
+      "content": [
+        "Preface:"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "is1",
+      "content": [
+        "A Word about the Contemporary English Version"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "imi",
+      "content": [
+        {
+          "type": "char",
+          "marker": "em",
+          "content": [
+            "Translation it is that opens the window, to let in the light; that breaks the shell, that we may eat the kernel; that puts aside the curtain, that we may look into the most holy place; that removes the cover of the well, that we may come by the water."
+          ]
+        },
+        " (“The Translators to the Reader,” King James Version, 1611)."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "im",
+      "content": [
+        "The most important document in the history of the English language is the ",
+        {
+          "type": "char",
+          "marker": "bk",
+          "content": [
+            "King James Version"
+          ]
+        },
+        " of the Bible..."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ib",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "imq",
+      "content": [
+        "Before Joseph died, he told his brothers, “I won't live much longer. But God will take"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ipq",
+      "content": [
+        "Before Joseph died, he told his brothers, “I won't live much longer. But God will take care of you and lead you out of Egypt to the land he promised Abraham, Isaac, and Jacob.”"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ipr",
+      "content": [
+        "(50.24)"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "iot",
+      "content": [
+        "A QUICK LOOK AT THIS BOOK"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "iq1",
+      "content": [
+        "God our Savior showed us"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "iq2",
+      "content": [
+        "how good and kind he is."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "iq1",
+      "content": [
+        "He saved us because"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "iq2",
+      "content": [
+        "of his mercy,"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "iq1",
+      "content": [
+        "and not because"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "iq2",
+      "content": [
+        "of any good things"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "iq2",
+      "content": [
+        "that we have done."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ipr",
+      "content": [
+        "(3.4,5a)"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ip",
+      "content": [
+        "However, he is more than a teacher, healer, or ",
+        {
+          "type": "char",
+          "marker": "w",
+          "content": [
+            "miracle"
+          ]
+        },
+        "-worker. He is also the Messiah, the Son of God, the Son of Man. These three titles express the first Christians' understanding of who Jesus is."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ili",
+      "content": [
+        "1 ",
+        {
+          "type": "char",
+          "marker": "k",
+          "content": [
+            "The Messiah"
+          ]
+        },
+        " is the one promised by God, the one who would come and free God's people. By the time ",
+        {
+          "type": "char",
+          "marker": "bk",
+          "content": [
+            "The Gospel of Mark"
+          ]
+        },
+        " appeared, the title \"Messiah\" (in Greek, \"",
+        {
+          "type": "char",
+          "marker": "w",
+          "content": [
+            "christ"
+          ]
+        },
+        "\") had become a proper name, so that the Gospel opens with \"the Good News about Jesus Christ\" (and not \"Jesus the Christ\"). Peter's confession (8.29) marks a turning-point in the ministry of Jesus. The title \"",
+        {
+          "type": "char",
+          "marker": "w",
+          "content": [
+            "son of david"
+          ]
+        },
+        " \" (10.46-48) also identifies Jesus as the Messiah, who would restore to Israel the power and glory it enjoyed under David's reign (also 12.35-37)."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ili",
+      "content": [
+        "2 ",
+        {
+          "type": "char",
+          "marker": "k",
+          "content": [
+            "The Son of God"
+          ]
+        },
+        " is the title by which the heavenly voice addresses Jesus at his baptism (1.11) and his transfiguration (9.7). And at Jesus' death the Roman officer confesses that Jesus is the Son of God (15.39)."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ili",
+      "content": [
+        "3 ",
+        {
+          "type": "char",
+          "marker": "k",
+          "content": [
+            "The Son of Man"
+          ]
+        },
+        " is the title most often used of Jesus, and it appears only on the lips of Jesus. This enigmatic title appears in ",
+        {
+          "type": "char",
+          "marker": "bk",
+          "content": [
+            "The Book of Daniel"
+          ]
+        },
+        " (Dan 7.13n), where it is applied to the exalted figure to whom God gives universal dominion. In ",
+        {
+          "type": "char",
+          "marker": "bk",
+          "content": [
+            "Mark"
+          ]
+        },
+        " the title is used of Jesus in three ways: the Son of Man acts with divine power (2.10, 28); he will be rejected, will suffer and die (8.31; 9.9, 12, 31; 10.33-34, 45; 14.21, 41); he will return in power and glory (8.38; 13.26; 14.62)."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ip",
+      "content": [
+        "The two endings to the Gospel, which are enclosed in brackets, are generally regarded as written by someone other than the author of ",
+        {
+          "type": "char",
+          "marker": "bk",
+          "content": [
+            "Mark"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "iot",
+      "content": [
+        "Outline of Contents"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "io1",
+      "content": [
+        "The beginning of the gospel (1.1-13)"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "io1",
+      "content": [
+        "Jesus' public ministry in Galilee (1.14–9.50)"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "io1",
+      "content": [
+        "From Galilee to Jerusalem (10.1-52)"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "io1",
+      "content": [
+        "The last week in and near Jerusalem (11.1–15.47)"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "io1",
+      "content": [
+        "The resurrection of Jesus (16.1-8)"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "io1",
+      "content": [
+        "The appearances and ascension of the risen Lord (16.9-20)"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "io1",
+      "content": [
+        "The beginning of the gospel ",
+        {
+          "type": "char",
+          "marker": "ior",
+          "content": [
+            "(1.1-13)"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "io1",
+      "content": [
+        "Jesus' public ministry in Galilee ",
+        {
+          "type": "char",
+          "marker": "ior",
+          "content": [
+            "(1.14–9.50)"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "io1",
+      "content": [
+        "From Galilee to Jerusalem ",
+        {
+          "type": "char",
+          "marker": "ior",
+          "content": [
+            "(10.1-52)"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "io1",
+      "content": [
+        "The last week in and near Jerusalem ",
+        {
+          "type": "char",
+          "marker": "ior",
+          "content": [
+            "(11.1–15.47)"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "io1",
+      "content": [
+        "The resurrection of Jesus ",
+        {
+          "type": "char",
+          "marker": "ior",
+          "content": [
+            "(16.1-8)"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "io1",
+      "content": [
+        "The appearances and ascension of the risen Lord ",
+        {
+          "type": "char",
+          "marker": "ior",
+          "content": [
+            "(16.9-20)"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "imte",
+      "content": [
+        "End of the Introduction to the Gospel of Mark"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ie",
+      "content": []
+    },
+    {
+      "type": "chapter",
+      "marker": "c",
+      "number": "1",
+      "sid": "TIT 1"
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "1",
+          "sid": "TIT 1:1"
+        },
+        "Paul, a servant of God and an apostle of Jesus Christ, for the faith of God's chosen people and the knowledge of the truth that agrees with godliness,"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "mte2",
+      "content": [
+        "The End of the Gospel according to"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "mte1",
+      "content": [
+        "John"
+      ]
+    }
+  ]
+}

--- a/tests/usfmjsTests/greek.oldformat/origin.json
+++ b/tests/usfmjsTests/greek.oldformat/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/greek/origin.json
+++ b/tests/usfmjsTests/greek/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/heb-12-27.grc/origin.json
+++ b/tests/usfmjsTests/heb-12-27.grc/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/heb1-1_multi_alignment/origin.json
+++ b/tests/usfmjsTests/heb1-1_multi_alignment/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",
@@ -8,13 +8,6 @@
       "code": "HEB",
       "content": [
         "EN_ULB en_English_ltr Wed Feb 07 2018 19:07:07 GMT-0500 (EST) tc"
-      ]
-    },
-    {
-      "type": "para",
-      "marker": "usfm",
-      "content": [
-        "3.0"
       ]
     },
     {

--- a/tests/usfmjsTests/hebrew_words.oldformat/origin.json
+++ b/tests/usfmjsTests/hebrew_words.oldformat/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/hebrew_words/origin.json
+++ b/tests/usfmjsTests/hebrew_words/origin.json
@@ -1,19 +1,12 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",
       "marker": "id",
       "code": "GEN",
       "content": []
-    },
-    {
-      "type": "para",
-      "marker": "usfm",
-      "content": [
-        "3.0"
-      ]
     },
     {
       "type": "chapter",

--- a/tests/usfmjsTests/inline_God/origin.json
+++ b/tests/usfmjsTests/inline_God/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/inline_words/origin.json
+++ b/tests/usfmjsTests/inline_words/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/isa_footnote/origin.json
+++ b/tests/usfmjsTests/isa_footnote/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/isa_inline_quotes/origin.json
+++ b/tests/usfmjsTests/isa_inline_quotes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/isa_verse_span/origin.json
+++ b/tests/usfmjsTests/isa_verse_span/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/jmp/origin.json
+++ b/tests/usfmjsTests/jmp/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/job_footnote/origin.json
+++ b/tests/usfmjsTests/job_footnote/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/links/origin.json
+++ b/tests/usfmjsTests/links/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/luk_quotes/origin.json
+++ b/tests/usfmjsTests/luk_quotes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/mat-4-6.whitespace/origin.json
+++ b/tests/usfmjsTests/mat-4-6.whitespace/origin.json
@@ -1,19 +1,12 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",
       "marker": "id",
       "code": "MAT",
       "content": []
-    },
-    {
-      "type": "para",
-      "marker": "usfm",
-      "content": [
-        "3.0"
-      ]
     },
     {
       "type": "chapter",

--- a/tests/usfmjsTests/mat-4-6/origin.json
+++ b/tests/usfmjsTests/mat-4-6/origin.json
@@ -1,19 +1,12 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",
       "marker": "id",
       "code": "MAT",
       "content": []
-    },
-    {
-      "type": "para",
-      "marker": "usfm",
-      "content": [
-        "3.0"
-      ]
     },
     {
       "type": "chapter",

--- a/tests/usfmjsTests/misc_footnotes/origin.json
+++ b/tests/usfmjsTests/misc_footnotes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/missing_verses/origin.json
+++ b/tests/usfmjsTests/missing_verses/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/nb/origin.json
+++ b/tests/usfmjsTests/nb/origin.json
@@ -1,0 +1,133 @@
+{
+  "type": "USJ",
+  "version": "3.1",
+  "content": [
+    {
+      "type": "book",
+      "marker": "id",
+      "code": "GEN",
+      "content": []
+    },
+    {
+      "type": "chapter",
+      "marker": "c",
+      "number": "1",
+      "sid": "GEN 1"
+    },
+    {
+      "type": "para",
+      "marker": "s1",
+      "content": [
+        "The Garden of Eden"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "1",
+          "sid": "GEN 1:1"
+        }
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        "When the ",
+        {
+          "type": "char",
+          "marker": "nd",
+          "content": [
+            "Lord"
+          ]
+        },
+        {
+          "type": "note",
+          "marker": "f",
+          "caller": "+",
+          "content": [
+            {
+              "type": "char",
+              "marker": "fr",
+              "content": [
+                "2.4: "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "fk",
+              "content": [
+                "the ",
+                {
+                  "type": "char",
+                  "marker": "nd",
+                  "content": [
+                    "Lord"
+                  ]
+                },
+                ": "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "ft",
+              "content": [
+                "Where the Hebrew text has Yahweh, traditionally transliterated as Jehovah, this translation employs ",
+                {
+                  "type": "char",
+                  "marker": "nd",
+                  "content": [
+                    "Lord"
+                  ]
+                },
+                " with capital letters, following a usage which is widespread in English versions."
+              ]
+            }
+          ]
+        },
+        " God made the universe, ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "5",
+          "sid": "GEN 1:5"
+        },
+        "there were no plants on the earth and no seeds had sprouted, because he had not sent any rain, and there was no one to cultivate the land; ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "14",
+          "sid": "GEN 1:14"
+        },
+        "That is why ",
+        {
+          "type": "char",
+          "marker": "bk",
+          "content": [
+            "The Book of the ",
+            {
+              "type": "char",
+              "marker": "nd",
+              "content": [
+                "Lord"
+              ]
+            },
+            "'s Battles"
+          ]
+        },
+        " speaks of “...the town of Waheb in the area of Suphah, and the valleys; the Arnon River, ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "15",
+          "sid": "GEN 1:15"
+        },
+        "and the slope of the valleys that extend to the town of Ar and toward the border of Moab.”"
+      ]
+    }
+  ]
+}

--- a/tests/usfmjsTests/out_of_sequence_chapters/origin.json
+++ b/tests/usfmjsTests/out_of_sequence_chapters/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/out_of_sequence_verses/origin.json
+++ b/tests/usfmjsTests/out_of_sequence_verses/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/pro_footnote/origin.json
+++ b/tests/usfmjsTests/pro_footnote/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/pro_quotes/origin.json
+++ b/tests/usfmjsTests/pro_quotes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/psa_quotes/origin.json
+++ b/tests/usfmjsTests/psa_quotes/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/qt/origin.json
+++ b/tests/usfmjsTests/qt/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tit1-1_alignment/origin.json
+++ b/tests/usfmjsTests/tit1-1_alignment/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",
@@ -8,13 +8,6 @@
       "code": "TIT",
       "content": [
         "Titus"
-      ]
-    },
-    {
-      "type": "para",
-      "marker": "usfm",
-      "content": [
-        "3.0"
       ]
     },
     {

--- a/tests/usfmjsTests/tit1-1_alignment_strongs/origin.json
+++ b/tests/usfmjsTests/tit1-1_alignment_strongs/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",
@@ -8,13 +8,6 @@
       "code": "TIT",
       "content": [
         "Titus"
-      ]
-    },
-    {
-      "type": "para",
-      "marker": "usfm",
-      "content": [
-        "3.0"
       ]
     },
     {

--- a/tests/usfmjsTests/tit_1_12.alignment/origin.json
+++ b/tests/usfmjsTests/tit_1_12.alignment/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",
@@ -8,13 +8,6 @@
       "code": "TIT",
       "content": [
         "Titus"
-      ]
-    },
-    {
-      "type": "para",
-      "marker": "usfm",
-      "content": [
-        "3.0"
       ]
     },
     {

--- a/tests/usfmjsTests/tit_1_12.no.words/origin.json
+++ b/tests/usfmjsTests/tit_1_12.no.words/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tit_1_12.oldformat/origin.json
+++ b/tests/usfmjsTests/tit_1_12.oldformat/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tit_1_12.word.not.at.line.start/origin.json
+++ b/tests/usfmjsTests/tit_1_12.word.not.at.line.start/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tit_1_12/origin.json
+++ b/tests/usfmjsTests/tit_1_12/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tit_1_12_footnote/origin.json
+++ b/tests/usfmjsTests/tit_1_12_footnote/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tit_1_12_new_line/origin.json
+++ b/tests/usfmjsTests/tit_1_12_new_line/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tit_extra_space_after_chapter/origin.json
+++ b/tests/usfmjsTests/tit_extra_space_after_chapter/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/ts/origin.json
+++ b/tests/usfmjsTests/ts/origin.json
@@ -1,0 +1,64 @@
+{
+  "type": "USJ",
+  "version": "3.1",
+  "content": [
+    {
+      "type": "book",
+      "marker": "id",
+      "code": "GEN",
+      "content": []
+    },
+    {
+      "type": "chapter",
+      "marker": "c",
+      "number": "1",
+      "sid": "GEN 1"
+    },
+    {
+      "type": "ms",
+      "marker": "ts"
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "5",
+          "sid": "GEN 1:5"
+        },
+        "Now I wish to remind you, although you know everything, that the Lord once saved a people out of the land of Egypt, but that afterward he destroyed those who did not believe. ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "6",
+          "sid": "GEN 1:6"
+        },
+        "And angels who did not keep to their own principality, but left their proper dwelling place—God has kept them in everlasting chains in darkness for the judgment of the great day. ",
+        {
+          "type": "ms",
+          "marker": "ts"
+        },
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "7",
+          "sid": "GEN 1:7"
+        },
+        "It is just like Sodom and Gomorrah and the cities around them, which in a similar way gave themselves over to fornication and pursued unnatural desires. They were given as examples of those who suffer the punishment of eternal fire. ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "8",
+          "sid": "GEN 1:8"
+        },
+        "Yet in the same way these also pollute their bodies in their dreams, and they reject authority, and they say evil things about the glorious ones. ",
+        {
+          "type": "ms",
+          "marker": "ts"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/usfmjsTests/ts_2/origin.json
+++ b/tests/usfmjsTests/ts_2/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tstudio/origin.json
+++ b/tests/usfmjsTests/tstudio/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/tw_words/origin.json
+++ b/tests/usfmjsTests/tw_words/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",
@@ -8,13 +8,6 @@
       "code": "TIT",
       "content": [
         "Titus"
-      ]
-    },
-    {
-      "type": "para",
-      "marker": "usfm",
-      "content": [
-        "3.0"
       ]
     },
     {

--- a/tests/usfmjsTests/tw_words_chunk/origin.json
+++ b/tests/usfmjsTests/tw_words_chunk/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/usfm-body-testF/origin.json
+++ b/tests/usfmjsTests/usfm-body-testF/origin.json
@@ -1,0 +1,1197 @@
+{
+  "type": "USJ",
+  "version": "3.1",
+  "content": [
+    {
+      "type": "book",
+      "marker": "id",
+      "code": "TIT",
+      "content": [
+        "Unlocked Literal Bible"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ide",
+      "content": [
+        "UTF-8"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "h",
+      "content": [
+        "Titus"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "toc1",
+      "content": [
+        "The Letter of Paul to Titus"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "toc2",
+      "content": [
+        "Titus"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "toc3",
+      "content": [
+        "Tit"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "mt",
+      "content": [
+        "Titus"
+      ]
+    },
+    {
+      "type": "chapter",
+      "marker": "c",
+      "number": "1",
+      "sid": "TIT 1"
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "1",
+          "sid": "TIT 1:1"
+        },
+        "Paul, a servant of God and an apostle of Jesus Christ, for the faith of God's chosen people and the knowledge of the truth that agrees with godliness, ",
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "grace",
+          "content": [
+            "gracious"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "grace",
+          "content": [
+            "gracious"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "grace",
+          "strong": "G5485",
+          "content": [
+            "gracious"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "strong": "G5485",
+          "content": [
+            "gracious"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "strong": "H1234,G5485",
+          "content": [
+            "gracious"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "strong": "G5485:a",
+          "content": [
+            "gracious"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "strong": "H6944,H6944",
+          "content": [
+            "most holy"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "grace",
+          "srcloc": "gnt5:51.1.2.1",
+          "content": [
+            "gracious"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "x-myattr": "metadata",
+          "content": [
+            "gracious"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "lemma": "grace",
+          "x-myattr": "metadata",
+          "content": [
+            "gracious"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "w",
+          "link-href": "http://bibles.org/search/grace/eng-GNTD/all",
+          "content": [
+            "gracious"
+          ]
+        },
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "2",
+          "sid": "TIT 1:2"
+        },
+        "with the certain hope of everlasting life that God, who does not lie, promised before all the ages of time. ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "3",
+          "sid": "TIT 1:3"
+        },
+        "At the right time, he revealed his word by the message that he trusted me to deliver, by the command of God our savior."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "4",
+          "sid": "TIT 1:4"
+        },
+        "To Titus, a true son in our common faith. Grace and peace from God the Father and Christ Jesus our savior."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "5",
+          "sid": "TIT 1:5"
+        },
+        "For this purpose I left you in Crete, that you might set in order things not yet complete and ordain elders in every city as I directed you. ",
+        {
+          "type": "char",
+          "marker": "rb",
+          "gloss": "gg:gg",
+          "content": [
+            "BB"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "rb",
+          "gloss": "gg:gg",
+          "content": [
+            "BB"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "rb",
+          "gloss": "g1::g3:",
+          "content": [
+            "BBBB"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "rb",
+          "gloss": "あい",
+          "content": [
+            "哀"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "rb",
+          "gloss": "はなはなし",
+          "content": [
+            "話賄"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "rb",
+          "gloss": "はな:はなし",
+          "content": [
+            "話賄"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "rb",
+          "gloss": "さだ:",
+          "content": [
+            "定ま"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "rb",
+          "gloss": "かみ::こ",
+          "content": [
+            "神の子"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "6",
+          "sid": "TIT 1:6"
+        },
+        "まだ",
+        {
+          "type": "char",
+          "marker": "rb",
+          "gloss": "なに",
+          "content": [
+            "何"
+          ]
+        },
+        "もなかった",
+        {
+          "type": "char",
+          "marker": "rb",
+          "gloss": "とき",
+          "content": [
+            "時"
+          ]
+        },
+        "、",
+        {
+          "type": "char",
+          "marker": "rb",
+          "gloss": "かみ",
+          "content": [
+            "神"
+          ]
+        },
+        "は ",
+        {
+          "type": "char",
+          "marker": "rb",
+          "gloss": "てん",
+          "content": [
+            "天"
+          ]
+        },
+        "と",
+        {
+          "type": "char",
+          "marker": "rb",
+          "gloss": "ち",
+          "content": [
+            "地"
+          ]
+        },
+        "を",
+        {
+          "type": "char",
+          "marker": "rb",
+          "gloss": "つく",
+          "content": [
+            "造"
+          ]
+        },
+        "りました。 ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "7",
+          "sid": "TIT 1:7"
+        },
+        {
+          "type": "char",
+          "marker": "rb",
+          "gloss": "ち",
+          "content": [
+            "地"
+          ]
+        },
+        "は",
+        {
+          "type": "char",
+          "marker": "rb",
+          "gloss": "かたち",
+          "content": [
+            "形"
+          ]
+        },
+        "も",
+        {
+          "type": "char",
+          "marker": "rb",
+          "gloss": "さだ",
+          "content": [
+            "定"
+          ]
+        },
+        "まらず、",
+        {
+          "type": "char",
+          "marker": "rb",
+          "gloss": "やみ",
+          "content": [
+            "闇"
+          ]
+        },
+        "に ",
+        {
+          "type": "char",
+          "marker": "rb",
+          "gloss": "つつ",
+          "content": [
+            "包"
+          ]
+        },
+        "まれた",
+        {
+          "type": "char",
+          "marker": "rb",
+          "gloss": "みず",
+          "content": [
+            "水"
+          ]
+        },
+        "の",
+        {
+          "type": "char",
+          "marker": "rb",
+          "gloss": "うえ",
+          "content": [
+            "上"
+          ]
+        },
+        "を、さらに",
+        {
+          "type": "char",
+          "marker": "rb",
+          "gloss": "かみ",
+          "content": [
+            "神"
+          ]
+        },
+        "の ",
+        {
+          "type": "char",
+          "marker": "rb",
+          "gloss": "れい",
+          "content": [
+            "霊"
+          ]
+        },
+        "が",
+        {
+          "type": "char",
+          "marker": "rb",
+          "gloss": "おお",
+          "content": [
+            "覆"
+          ]
+        },
+        "っていました。"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "8",
+          "sid": "TIT 1:8"
+        },
+        "Instead, he should be hospitable and a friend of what is good. He must be sensible, righteous, godly, and self-controlled. ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "9",
+          "sid": "TIT 1:9"
+        },
+        "He should hold tightly to the trustworthy message that was taught, so that he may be able to encourage others with good teaching and correct those who oppose him."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "q1",
+      "content": [
+        "“Someone is shouting in the desert,"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "q2",
+      "content": [
+        "‘Prepare a road for the Lord;"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "q2",
+      "content": [
+        "make a straight path for him to travel!’ ”"
+      ]
+    },
+    {
+      "type": "sidebar",
+      "marker": "esb",
+      "category": "People",
+      "content": [
+        {
+          "type": "para",
+          "marker": "ms",
+          "content": [
+            {
+              "type": "char",
+              "marker": "jmp",
+              "link-id": "article-john_the_baptist",
+              "content": []
+            },
+            "John the Baptist"
+          ]
+        },
+        {
+          "type": "para",
+          "marker": "p",
+          "content": [
+            "John is sometimes called the last “Old Testament prophet” because of the warnings he brought about God's judgment and because he announced the coming of God's “Chosen One” (Messiah)."
+          ]
+        },
+        {
+          "type": "para",
+          "marker": "s5",
+          "content": []
+        },
+        {
+          "type": "para",
+          "marker": "p",
+          "content": []
+        },
+        {
+          "type": "para",
+          "marker": "q1",
+          "content": [
+            {
+              "type": "ms",
+              "marker": "qt2-s",
+              "who": "someone"
+            },
+            "‘In him we live and move and exist.’",
+            {
+              "type": "ms",
+              "marker": "qt2-e"
+            }
+          ]
+        },
+        {
+          "type": "para",
+          "marker": "b"
+        },
+        {
+          "type": "para",
+          "marker": "m",
+          "content": [
+            "It is as some of your poets have said,"
+          ]
+        },
+        {
+          "type": "para",
+          "marker": "q1",
+          "content": [
+            {
+              "type": "ms",
+              "marker": "qt2-s",
+              "who": "some poets"
+            },
+            "‘We too are his children.’",
+            {
+              "type": "ms",
+              "marker": "qt2-e"
+            }
+          ]
+        },
+        {
+          "type": "para",
+          "marker": "b"
+        },
+        {
+          "type": "para",
+          "marker": "m",
+          "content": []
+        }
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "10",
+          "sid": "TIT 1:10"
+        },
+        "For there are many rebellious people, empty talkers and deceivers, especially those of the circumcision. ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "11",
+          "sid": "TIT 1:11"
+        },
+        "Jesus stood before the Roman governor, who questioned him. ",
+        {
+          "type": "ms",
+          "marker": "qt-s",
+          "who": "Pilate"
+        },
+        "“Are you the king of the Jews?”",
+        {
+          "type": "ms",
+          "marker": "qt-e"
+        },
+        " he asked."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "ms",
+          "marker": "qt-s",
+          "who": "Jesus"
+        },
+        "“So you say,”",
+        {
+          "type": "ms",
+          "marker": "qt-e"
+        },
+        " answered Jesus. ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "12",
+          "sid": "TIT 1:12"
+        },
+        "Paul stood up in front of the city council and said, ",
+        {
+          "type": "ms",
+          "marker": "qt1-s",
+          "sid": "qt1_ACT_17:22",
+          "who": "Paul"
+        },
+        "“I see that in every way you Athenians are very religious."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "13",
+          "sid": "TIT 1:13"
+        },
+        "So Pilate said to him, ",
+        {
+          "type": "ms",
+          "marker": "qt-s",
+          "who": "Pilate"
+        },
+        "“Don't you hear all these things they accuse you of?”",
+        {
+          "type": "ms",
+          "marker": "qt-e"
+        }
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "14",
+          "sid": "TIT 1:14"
+        },
+        "not paying any attention to Jewish myths or to the commands of people who turn away from the truth."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "15",
+          "sid": "TIT 1:15"
+        },
+        "To those who are pure, all things are pure. But to those who are corrupt and unbelieving, nothing is pure, but both their minds and their consciences have been corrupted. ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "16",
+          "sid": "TIT 1:16"
+        },
+        "They profess to know God, but they deny him by their actions. They are detestable, disobedient, and unfit for doing any good work."
+      ]
+    },
+    {
+      "type": "chapter",
+      "marker": "c",
+      "number": "2",
+      "sid": "TIT 2"
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "1",
+          "sid": "TIT 2:1"
+        },
+        "But you, speak what fits with faithful instruction. The traditional translation of verse 1, as given in ",
+        {
+          "type": "char",
+          "marker": "jmp",
+          "link-href": "prj:RSV52 GEN 1:1",
+          "link-title": "Revised Standard Version",
+          "content": [
+            "RSV"
+          ]
+        },
+        ", may be appropriate. Storehouses, as used here, refers to large buildings with walls and roof, where grain was kept until needed. (See illustration: ",
+        {
+          "type": "char",
+          "marker": "jmp",
+          "link-href": "figures/storehouse.png",
+          "link-title": "Ancient storehouse",
+          "content": [
+            "Storehouse"
+          ]
+        },
+        ") ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "2",
+          "sid": "TIT 2:2"
+        },
+        "Teach older men to be temperate, dignified, sensible, sound in faith, in love, and in perseverance."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "3",
+          "sid": "TIT 2:3"
+        },
+        "Teach older women likewise to be reverent in behavior, not slanderers or being slaves to much wine, but to be teachers of what is good. ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "4",
+          "sid": "TIT 2:4"
+        },
+        "In this way they may train the younger women to love their own husbands and children,"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "5",
+          "sid": "TIT 2:5"
+        },
+        "From Abraham to King David, the following ancestors are listed: Abraham, Isaac, Jacob, Judah and his brothers; then Perez and Zerah (their mother was Tamar*), Hezron, Ram, Amminadab, Nahshon, Salmon, Boaz (his mother was Rahab*), Obed (his mother was ",
+        {
+          "type": "char",
+          "marker": "jmp",
+          "link-href": "#article-Ruth",
+          "content": [
+            "Ruth"
+          ]
+        },
+        "), Jesse, and King David. ",
+        {
+          "type": "note",
+          "marker": "f",
+          "caller": "-",
+          "content": [
+            {
+              "type": "char",
+              "marker": "fr",
+              "content": [
+                "1.2-6a: "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "fq",
+              "content": [
+                "Ruth: "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "ft",
+              "content": [
+                "A Moabite (Ruth 1.4). Only outstanding women were normally included in Jewish genealogical lists. See article on ",
+                {
+                  "type": "char",
+                  "marker": "jmp",
+                  "link-href": "#article-Ruth",
+                  "content": [
+                    "Ruth"
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": [
+        {
+          "type": "ms",
+          "marker": "ts-s",
+          "sid": "ts_JUD_5-6"
+        }
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "6",
+          "sid": "TIT 2:6"
+        },
+        "Now I wish to remind you, although you know everything, that the Lord once saved a people out of the land of Egypt, but that afterward he destroyed those who did not believe. ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "7",
+          "sid": "TIT 2:7"
+        },
+        "And angels who did not keep to their own principality, but left their proper dwelling place—God has kept them in everlasting chains in darkness for the judgment of the great day. ",
+        {
+          "type": "ms",
+          "marker": "ts-e",
+          "eid": "ts_JUD_5-6"
+        },
+        {
+          "type": "ms",
+          "marker": "ts-s",
+          "sid": "ts_JUD_7-8"
+        },
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "8",
+          "sid": "TIT 2:8"
+        },
+        "It is just like Sodom and Gomorrah and the cities around them, which in a similar way gave themselves over to fornication and pursued unnatural desires. They were given as examples of those who suffer the punishment of eternal fire. ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "9",
+          "sid": "TIT 2:9"
+        },
+        "Yet in the same way these also pollute their bodies in their dreams, and they reject authority, and they say evil things about the glorious ones. ",
+        {
+          "type": "ms",
+          "marker": "ts-e",
+          "eid": "ts_JUD_7-8"
+        }
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "10",
+          "sid": "TIT 2:10"
+        },
+        "to not steal from them, but instead to demonstrate all good faith, so that in every way they may bring credit to the teaching about God our Savior."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "11",
+          "sid": "TIT 2:11"
+        },
+        "For the grace of God has appeared for the salvation of all people. ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "12",
+          "sid": "TIT 2:12"
+        },
+        "It trains us to reject godlessness and worldly passions, and to live self-controlled, upright, and godly lives in this age, ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "13",
+          "sid": "TIT 2:13"
+        },
+        "while we look forward to receiving our blessed hope, the appearance of the glory of our great God and Savior Jesus Christ."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "14",
+          "sid": "TIT 2:14"
+        },
+        "Jesus gave himself for us in order to redeem us from all lawlessness and to make pure, for himself, a special people who are eager to do good works."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "15",
+          "sid": "TIT 2:15"
+        },
+        "Speak of these things, encourage people to do them, and give correction with all authority. Let no one disregard you."
+      ]
+    },
+    {
+      "type": "chapter",
+      "marker": "c",
+      "number": "3",
+      "sid": "TIT 3"
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "1",
+          "sid": "TIT 3:1"
+        },
+        "Remind them to submit to rulers and authorities, to obey them, to be ready for every good work, ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "2",
+          "sid": "TIT 3:2"
+        },
+        "to revile no one, to not be eager to fight, and to be gentle, showing all humility toward everyone."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "3",
+          "sid": "TIT 3:3"
+        },
+        "For he has fixed a day in which he will judge the whole world with justice by means of a man he has chosen. He has given proof of this to everyone by raising that man from death!” ",
+        {
+          "type": "ms",
+          "marker": "qt1-e",
+          "eid": "qt1_ACT_17:22"
+        }
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "4",
+          "sid": "TIT 3:4"
+        },
+        "But when the kindness of God our savior and his love for mankind appeared, ",
+        {
+          "type": "ms",
+          "marker": "ts"
+        }
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "5",
+          "sid": "TIT 3:5"
+        },
+        "Now I wish to remind you, although you know everything, that the Lord once saved a people out of the land of Egypt, but that afterward he destroyed those who did not believe. ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "6",
+          "sid": "TIT 3:6"
+        },
+        "And angels who did not keep to their own principality, but left their proper dwelling place—God has kept them in everlasting chains in darkness for the judgment of the great day. ",
+        {
+          "type": "ms",
+          "marker": "ts"
+        },
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "7",
+          "sid": "TIT 3:7"
+        },
+        "It is just like Sodom and Gomorrah and the cities around them, which in a similar way gave themselves over to fornication and pursued unnatural desires. They were given as examples of those who suffer the punishment of eternal fire. ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "8",
+          "sid": "TIT 3:8"
+        },
+        "Yet in the same way these also pollute their bodies in their dreams, and they reject authority, and they say evil things about the glorious ones. ",
+        {
+          "type": "ms",
+          "marker": "ts"
+        }
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "9",
+          "sid": "TIT 3:9"
+        },
+        "But avoid foolish debates and genealogies and strife and conflict about the law. Those things are unprofitable and worthless. ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "10",
+          "sid": "TIT 3:10"
+        },
+        "Reject anyone who is causing divisions among you, after one or two warnings, ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "11",
+          "sid": "TIT 3:11"
+        },
+        "knowing that such a person has turned from the right way and is sinning and condemns himself."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "12",
+          "sid": "TIT 3:12"
+        },
+        "When I send Artemas or Tychicus to you, hurry and come to me at Nicopolis, where I have decided to spend the winter. ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "13",
+          "sid": "TIT 3:13"
+        },
+        "Do everything you can to send on their way Zenas the lawyer and Apollos, so that they lack nothing."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "14",
+          "sid": "TIT 3:14"
+        },
+        "Our people must learn to engage themselves in good works that provide for urgent needs, and so not be unfruitful."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "15",
+          "sid": "TIT 3:15"
+        },
+        "All those who are with me greet you. Greet those who love us in faith. Grace be with all of you."
+      ]
+    }
+  ]
+}

--- a/tests/usfmjsTests/usfmBodyTestD/origin.json
+++ b/tests/usfmjsTests/usfmBodyTestD/origin.json
@@ -1,0 +1,1411 @@
+{
+  "type": "USJ",
+  "version": "3.1",
+  "content": [
+    {
+      "type": "book",
+      "marker": "id",
+      "code": "TIT",
+      "content": [
+        "41MATGNT92.SFM, Good News Translation, June 2003"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "ip",
+      "content": [
+        {
+          "type": "char",
+          "marker": "bk",
+          "content": [
+            "The Acts of the Apostles"
+          ]
+        },
+        " is a continuation of ",
+        {
+          "type": "char",
+          "marker": "bk",
+          "content": [
+            "The Gospel according to Luke"
+          ]
+        },
+        " Its chief purpose is to tell how Jesus' early followers, led by the Holy Spirit, spread the Good News about him “in Jerusalem, in all of Judea and Samaria, and to the ends of the earth” (1.8)."
+      ]
+    },
+    {
+      "type": "chapter",
+      "marker": "c",
+      "number": "1",
+      "sid": "TIT 1"
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "s1",
+      "content": [
+        "The Preaching of John the Baptist",
+        {
+          "type": "note",
+          "marker": "x",
+          "caller": "-",
+          "content": [
+            {
+              "type": "char",
+              "marker": "xo",
+              "content": [
+                "3.0 "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "xta",
+              "content": [
+                "Compare with "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "xt",
+              "content": [
+                "Mk 1.1-8; Lk 3.1-18; "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "xta",
+              "content": [
+                "and "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "xt",
+              "content": [
+                "Jn 1.19-28 "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "xta",
+              "content": [
+                "parallel passages."
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "1",
+          "sid": "TIT 1:1"
+        },
+        "This is the Good News about Jesus Christ, the Son of God. ",
+        {
+          "type": "note",
+          "marker": "f",
+          "caller": "+",
+          "content": [
+            {
+              "type": "char",
+              "marker": "fr",
+              "content": [
+                "1.1: "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "ft",
+              "content": [
+                "Some manuscripts do not have "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "fq",
+              "content": [
+                "the Son of God."
+              ]
+            }
+          ]
+        },
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "2",
+          "sid": "TIT 1:2"
+        },
+        "with the certain hope of everlasting life that God, who does not lie, promised before all the ages of time. ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "2-7",
+          "sid": "TIT 1:2-7"
+        },
+        "They presented their offerings in the following order:"
+      ]
+    },
+    {
+      "type": "table",
+      "content": [
+        {
+          "type": "table:row",
+          "marker": "tr",
+          "content": [
+            {
+              "type": "table:cell",
+              "marker": "th1",
+              "align": "start",
+              "content": [
+                "Day "
+              ]
+            },
+            {
+              "type": "table:cell",
+              "marker": "th2",
+              "align": "start",
+              "content": [
+                "Tribe "
+              ]
+            },
+            {
+              "type": "table:cell",
+              "marker": "th3",
+              "align": "start",
+              "content": [
+                "Leader"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "table:row",
+          "marker": "tr",
+          "content": [
+            {
+              "type": "table:cell",
+              "marker": "tcr1",
+              "align": "end",
+              "content": [
+                "1st "
+              ]
+            },
+            {
+              "type": "table:cell",
+              "marker": "tc2",
+              "align": "start",
+              "content": [
+                "Judah "
+              ]
+            },
+            {
+              "type": "table:cell",
+              "marker": "tc3",
+              "align": "start",
+              "content": [
+                "Nahshon son of Amminadab"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "table:row",
+          "marker": "tr",
+          "content": [
+            {
+              "type": "table:cell",
+              "marker": "tcr1",
+              "align": "end",
+              "content": [
+                "2nd "
+              ]
+            },
+            {
+              "type": "table:cell",
+              "marker": "tc2",
+              "align": "start",
+              "content": [
+                "Issachar "
+              ]
+            },
+            {
+              "type": "table:cell",
+              "marker": "tc3",
+              "align": "start",
+              "content": [
+                "Nethanel son of Zuar"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "table:row",
+          "marker": "tr",
+          "content": [
+            {
+              "type": "table:cell",
+              "marker": "tc1",
+              "align": "start",
+              "content": [
+                "Judah "
+              ]
+            },
+            {
+              "type": "table:cell",
+              "marker": "tc2",
+              "align": "start",
+              "content": [
+                "Nahshon son of Amminadab "
+              ]
+            },
+            {
+              "type": "table:cell",
+              "marker": "tcr3",
+              "align": "end",
+              "content": [
+                "74,600"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "table:row",
+          "marker": "tr",
+          "content": [
+            {
+              "type": "table:cell",
+              "marker": "tc1",
+              "align": "start",
+              "content": [
+                "Issachar "
+              ]
+            },
+            {
+              "type": "table:cell",
+              "marker": "tc2",
+              "align": "start",
+              "content": [
+                "Nethanel son of Zuar "
+              ]
+            },
+            {
+              "type": "table:cell",
+              "marker": "tcr3",
+              "align": "end",
+              "content": [
+                "54,400"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "3",
+          "sid": "TIT 1:3"
+        },
+        "At the right time, he revealed his word by the message that he trusted me to deliver, by the command of God our savior."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "4",
+          "sid": "TIT 1:4"
+        },
+        "To Titus, a true son in our common faith. Grace and peace from God the Father and Christ Jesus our savior."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "5",
+          "sid": "TIT 1:5"
+        },
+        "For this purpose I left you in Crete, that you might set in order things not yet complete and ordain elders in every city as I directed you."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "6",
+          "sid": "TIT 1:6"
+        },
+        "An elder must be without blame, the husband of one wife, with faithful children not accused of reckless behavior or undisciplined. ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "7",
+          "sid": "TIT 1:7"
+        },
+        "It is necessary for the overseer, as God's household manager, to be blameless. He must not be arrogant, not be easily angered, not addicted to wine, not a brawler, and not a greedy man."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "8",
+          "sid": "TIT 1:8"
+        },
+        "Instead, he should be hospitable and a friend of what is good. He must be sensible, righteous, godly, and self-controlled. ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "9",
+          "sid": "TIT 1:9"
+        },
+        "И нарек ему имя: Ной, сказав: он утешит нас в работе нашей и в трудах рук наших при ",
+        {
+          "type": "char",
+          "marker": "add",
+          "content": [
+            "возделывании"
+          ]
+        },
+        " земли, которую проклял Господь."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "10",
+          "sid": "TIT 1:10"
+        },
+        "For there are many rebellious people, empty talkers and deceivers, especially those of the circumcision. ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "11",
+          "sid": "TIT 1:11"
+        },
+        "It is necessary to stop them. They are upsetting whole families by teaching for shameful profit what they should not teach."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "12",
+          "sid": "TIT 1:12"
+        },
+        "One of their own prophets has said, \"Cretans are always liars, evil beasts, lazy gluttons.\" ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "13",
+          "sid": "TIT 1:13"
+        },
+        "This statement is true. Therefore, correct them severely, so that they may be sound in the faith, ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "14",
+          "sid": "TIT 1:14"
+        },
+        "not paying any attention to Jewish myths or to the commands of people who turn away from the truth."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "15",
+          "sid": "TIT 1:15"
+        },
+        "Adam ",
+        {
+          "type": "note",
+          "marker": "f",
+          "caller": "+",
+          "content": [
+            {
+              "type": "char",
+              "marker": "fr",
+              "content": [
+                "3.20: "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "fk",
+              "content": [
+                "Adam: "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "ft",
+              "content": [
+                "This name in Hebrew means “all human beings.”"
+              ]
+            }
+          ]
+        },
+        " named his wife Eve, ",
+        {
+          "type": "note",
+          "marker": "f",
+          "caller": "+",
+          "content": [
+            {
+              "type": "char",
+              "marker": "fr",
+              "content": [
+                "3.20: "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "fk",
+              "content": [
+                "Eve: "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "ft",
+              "content": [
+                "This name sounds similar to the Hebrew word for “living,” which is rendered in this context as “human beings.”"
+              ]
+            }
+          ]
+        },
+        " because she was the mother of all human beings. ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "16",
+          "sid": "TIT 1:16"
+        },
+        "And the ",
+        {
+          "type": "char",
+          "marker": "nd",
+          "content": [
+            "Lord"
+          ]
+        },
+        " God made clothes out of animal skins for Adam and his wife, and he clothed them. ",
+        {
+          "type": "note",
+          "marker": "f",
+          "caller": "⸀",
+          "content": [
+            {
+              "type": "char",
+              "marker": "fr",
+              "content": [
+                "28,14 "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "ft",
+              "content": [
+                "υπο "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "fw",
+              "content": [
+                "B D 0148. 892"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "note",
+          "marker": "f",
+          "caller": "°",
+          "content": [
+            {
+              "type": "char",
+              "marker": "fr",
+              "content": [
+                "4,1 "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "fw",
+              "content": [
+                "B Δ 700"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "chapter",
+      "marker": "c",
+      "number": "2",
+      "sid": "TIT 2"
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "1-2",
+          "sid": "TIT 2:1-2"
+        },
+        {
+          "type": "note",
+          "marker": "x",
+          "caller": "-",
+          "content": [
+            {
+              "type": "char",
+              "marker": "xo",
+              "content": [
+                "2.1,22: "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "xdc",
+              "content": [
+                "2Es 6.23; "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "xt",
+              "content": [
+                "1Th 4.15-17."
+              ]
+            }
+          ]
+        },
+        " Listen to this secret truth: we shall not all die, but when the last trumpet sounds, we shall all be changed in an instant, as quickly as the blinking of an eye. For when the trumpet sounds, the dead will be raised, never to die again, and we shall all be changed. ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "2",
+          "sid": "TIT 2:2"
+        },
+        "Teach older men to be temperate, dignified, sensible, sound in faith, in love, and in perseverance."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "3",
+          "sid": "TIT 2:3"
+        },
+        "Él es el resplandor glorioso de Dios,",
+        {
+          "type": "note",
+          "marker": "f",
+          "caller": "c",
+          "content": [
+            {
+              "type": "char",
+              "marker": "fr",
+              "content": [
+                "1.3: "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "fk",
+              "content": [
+                "Resplandor: "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "ft",
+              "content": [
+                "Cf. Jn 1.4-9,14"
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "fdc",
+              "content": [
+                "; también Sab 7.25-26, donde algo parecido se dice de la sabiduría."
+              ]
+            }
+          ]
+        },
+        " la imagen misma de lo que Dios es y el que sostiene todas las cosas con su palabra poderosa. Después de limpiarnos de nuestros pecados, se ha sentado en el cielo, a la derecha del trono de Dios, ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "4",
+          "sid": "TIT 2:4"
+        },
+        "y ha llegado a ser superior a los ángeles, pues ha recibido en herencia un título mucho más importante que el de ellos. ",
+        {
+          "type": "note",
+          "marker": "fe",
+          "caller": "-",
+          "content": [
+            {
+              "type": "char",
+              "marker": "ft",
+              "content": [
+                "this is some text"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "5",
+          "sid": "TIT 2:5"
+        },
+        "to be sensible, pure, good housekeepers, and obedient to their own husbands, so that God's word may not be insulted."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "6",
+          "sid": "TIT 2:6"
+        },
+        "In the same way, encourage the younger men to use good sense. ",
+        {
+          "type": "char",
+          "marker": "xt",
+          "link-href": "MAT 6:7",
+          "content": [
+            "7"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "xt",
+          "link-href": "MAT 6:7",
+          "content": [
+            "verse 7"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "xt",
+          "link-href": "MAT 6:7",
+          "content": [
+            "v7"
+          ]
+        },
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "8",
+          "sid": "TIT 2:8"
+        },
+        "and a correct message that is above criticism, so that anyone who opposes you may be ashamed because they have nothing bad to say about us."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "9",
+          "sid": "TIT 2:9"
+        },
+        {
+          "type": "note",
+          "marker": "x",
+          "caller": "-",
+          "content": [
+            {
+              "type": "char",
+              "marker": "xo",
+              "content": [
+                "2.9: a "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "xt",
+              "content": [
+                "Exo 20.13; Deu 5.17; "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "xo",
+              "content": [
+                "b "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "xt",
+              "content": [
+                "Exo 20.14; Deu 5.18; "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "xo",
+              "content": [
+                "c "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "xt",
+              "content": [
+                "Exo 20.15; Deu 5.19; "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "xo",
+              "content": [
+                "d "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "xt",
+              "content": [
+                "Exo 20.16; Deu 5.20; "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "xo",
+              "content": [
+                "e "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "xt",
+              "content": [
+                "Exo 20.12; Deu 5.16."
+              ]
+            }
+          ]
+        },
+        " You know the commandments: ‘Do not commit murder; do not commit adultery; do not steal; do not accuse anyone falsely; do not cheat; respect your father and your mother.’” ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "10",
+          "sid": "TIT 2:10"
+        },
+        "to not steal from them, but instead to demonstrate all good faith, so that in every way they may bring credit to the teaching about God our Savior."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "11",
+          "sid": "TIT 2:11"
+        },
+        "For the grace of God has appeared for the salvation of all people. ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "12",
+          "sid": "TIT 2:12"
+        },
+        "It trains us to reject godlessness and worldly passions, and to live self-controlled, upright, and godly lives in this age, ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "13",
+          "sid": "TIT 2:13"
+        },
+        "while we look forward to receiving our blessed hope, the appearance of the glory of our great God and Savior Jesus Christ."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "14",
+          "sid": "TIT 2:14"
+        },
+        "Jesus gave himself for us in order to redeem us from all lawlessness and to make pure, for himself, a special people who are eager to do good works."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "15",
+          "sid": "TIT 2:15"
+        },
+        "Speak of these things, encourage people to do them, and give correction with all authority. Let no one disregard you."
+      ]
+    },
+    {
+      "type": "chapter",
+      "marker": "c",
+      "number": "3",
+      "sid": "TIT 3"
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "1",
+          "sid": "TIT 3:1"
+        },
+        {
+          "type": "note",
+          "marker": "x",
+          "caller": "-",
+          "content": [
+            {
+              "type": "char",
+              "marker": "xo",
+              "content": [
+                "1:1 "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "xop",
+              "content": [
+                "Гл 1. (1)"
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "xt",
+              "content": [
+                "4 Царств. 14:25."
+              ]
+            }
+          ]
+        },
+        "И биде слово Господне към Иона, син Аматиев: ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "2",
+          "sid": "TIT 3:2"
+        },
+        {
+          "type": "note",
+          "marker": "x",
+          "caller": "-",
+          "content": [
+            {
+              "type": "char",
+              "marker": "xo",
+              "content": [
+                "1:2 "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "xop",
+              "content": [
+                "(2)"
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "xt",
+              "content": [
+                "Бит. 10:11. Иона 3:3."
+              ]
+            }
+          ]
+        },
+        "„стани, иди в Ниневия,"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "3",
+          "sid": "TIT 3:3"
+        },
+        "Él es el resplandor glorioso de Dios,",
+        {
+          "type": "note",
+          "marker": "f",
+          "caller": "c",
+          "content": [
+            {
+              "type": "char",
+              "marker": "fr",
+              "content": [
+                "1.3: "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "fk",
+              "content": [
+                "Resplandor: "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "ft",
+              "content": [
+                "Cf. Jn 1.4-9,14",
+                {
+                  "type": "char",
+                  "marker": "dc",
+                  "content": [
+                    "; también Sab 7.25-26, donde algo parecido se dice de la sabiduría"
+                  ]
+                },
+                "."
+              ]
+            }
+          ]
+        },
+        " la imagen misma de lo que Dios es y el que sostiene todas las cosas con su palabra poderosa. Después de limpiarnos de nuestros pecados, se ha sentado en el cielo, a la derecha del trono de Dios, ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "4",
+          "sid": "TIT 3:4"
+        },
+        {
+          "type": "note",
+          "marker": "x",
+          "caller": "-",
+          "content": [
+            {
+              "type": "char",
+              "marker": "xo",
+              "content": [
+                "115.4-8: "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "xt",
+              "content": [
+                "Ps 135.15-18; ",
+                {
+                  "type": "char",
+                  "marker": "dc",
+                  "content": [
+                    "Ltj Jr 4-73; "
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "xt",
+              "content": [
+                "Rev 9.20."
+              ]
+            }
+          ]
+        },
+        " Their gods are made of silver and gold, ",
+        {
+          "type": "char",
+          "marker": "k",
+          "content": [
+            "keyword "
+          ]
+        }
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "lit",
+      "content": [
+        "Literally: ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "5",
+          "sid": "TIT 3:5"
+        },
+        "Tell the Israelites that I, the ",
+        {
+          "type": "char",
+          "marker": "nd",
+          "content": [
+            "Lord"
+          ]
+        },
+        ", the God of their ancestors, the God of Abraham, Isaac, and Jacob, have sent you to them. This is my name forever; this is what all future generations are to call me."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "6",
+          "sid": "TIT 3:6"
+        },
+        "whom God richly poured on us through our Savior Jesus Christ, ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "6-9",
+          "sid": "TIT 3:6-9"
+        },
+        "This is the list of the administrators of the tribes of Israel:"
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "li1",
+      "content": [
+        {
+          "type": "char",
+          "marker": "lik",
+          "content": [
+            "Reuben"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "liv1",
+          "content": [
+            "Eliezer son of Zichri"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "li1",
+      "content": [
+        {
+          "type": "char",
+          "marker": "lik",
+          "content": [
+            "Simeon"
+          ]
+        },
+        {
+          "type": "char",
+          "marker": "liv1",
+          "content": [
+            "Shephatiah son of Maacah"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "lf",
+      "content": [
+        "This was the list of the administrators of the tribes of Israel. ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "7",
+          "sid": "TIT 3:7"
+        },
+        "so that having been justified by his grace, we might become heirs with the certain hope of eternal life."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "8",
+          "sid": "TIT 3:8"
+        },
+        "whoever believes in me should drink. As the scripture says, ‘Streams of life- giving water will pour out from his side.’” ",
+        {
+          "type": "note",
+          "marker": "f",
+          "caller": "+",
+          "content": [
+            {
+              "type": "char",
+              "marker": "fr",
+              "content": [
+                "7.38: "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "ft",
+              "content": [
+                "Jesus' words in verses 37-38 may be translated: "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "fqa",
+              "content": [
+                "“Whoever is thirsty should come to me and drink. "
+              ]
+            },
+            {
+              "type": "char",
+              "marker": "fv",
+              "content": [
+                "8"
+              ]
+            },
+            " As the scripture says, ‘Streams of life-giving water will pour out from within anyone who believes in me.’”"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "9",
+          "sid": "TIT 3:9"
+        },
+        "But avoid foolish debates and genealogies and strife and conflict about the law. Those things are unprofitable and worthless. ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "10",
+          "sid": "TIT 3:10"
+        },
+        "Reject anyone who is causing divisions among you, after one or two warnings, ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "11",
+          "sid": "TIT 3:11"
+        },
+        "knowing that such a person has turned from the right way and is sinning and condemns himself."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "12",
+          "sid": "TIT 3:12"
+        },
+        "When I send Artemas or Tychicus to you, hurry and come to me at Nicopolis, where I have decided to spend the winter. ",
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "13",
+          "sid": "TIT 3:13"
+        },
+        "Do everything you can to send on their way Zenas the lawyer and Apollos, so that they lack nothing."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "14",
+          "sid": "TIT 3:14"
+        },
+        "Our people must learn to engage themselves in good works that provide for urgent needs, and so not be unfruitful."
+      ]
+    },
+    {
+      "type": "para",
+      "marker": "s5",
+      "content": []
+    },
+    {
+      "type": "para",
+      "marker": "p",
+      "content": [
+        {
+          "type": "verse",
+          "marker": "v",
+          "number": "15",
+          "sid": "TIT 3:15"
+        },
+        "All those who are with me greet you. Greet those who love us in faith. Grace be with all of you."
+      ]
+    }
+  ]
+}

--- a/tests/usfmjsTests/usfmIntroTest/origin.json
+++ b/tests/usfmjsTests/usfmIntroTest/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",

--- a/tests/usfmjsTests/valid/origin.json
+++ b/tests/usfmjsTests/valid/origin.json
@@ -1,6 +1,6 @@
 {
   "type": "USJ",
-  "version": "0.2.3",
+  "version": "3.1",
   "content": [
     {
       "type": "book",


### PR DESCRIPTION
- Changes version number in USJ samples in `tests/` to 3.1
- Changes version number to 3.1 within code that generates USJ from USX
  - at python/scripts/usx2usj.py
  - at python/lib/usfmtc/usjproc.py
- Include the previously missed code portion for building USJ root element in  python/lib/usfmtc/usjproc.py(https://github.com/usfm-bible/tcdocs/pull/66#issuecomment-1965770088)
- While re-running USJ generation from USX in testsuite, more samples could be converted than before.
  ```
  Stats
  ------
  USFM samples: 258
  USX samples: 256
  USJ samples generated only for: 234
  (Converted only where USX was present and did not have elements with status='invalid' or other issues in it.)
  ```
