### PR TITLE
Fix the  field of USJ schema

### DIFF
--- a/grammar/usj.js
+++ b/grammar/usj.js
@@ -1,6 +1,6 @@
 {
-  "$schema": "USJ-0.2.3",
-  "$id": "https://usfm-committee/usj.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://github.com/usfm-bible/tcdocs/blob/main/grammar/usj.js",
   "title": "Unified Scripture JSON",
   "description": "The JSON varient of USFM and USX data models",
   "type": "object",
@@ -59,7 +59,7 @@
           "type": "string"
         }
       },
-      "required": ["type", "marker"]
+      "required": ["type"]
     }
    },
   "properties": {


### PR DESCRIPTION
1. The `$schema` field of the JSON-schema expects a proper spec. Even though python library was able to parse the schema file without it, javascript libraries expects a correct value.
2. The `$id` filed was earlier set to a dummy value. Now it points to the file location in tcdocs repo.
3. As `ref` object has been introduced without a "marker" field, that property is now made not mandatory.