### PR TITLE
Remove duplicate "ipc" style

### DIFF
--- a/grammar/usx.rnc
+++ b/grammar/usx.rnc
@@ -504,8 +504,6 @@ Introduction.para.style.enum = (
       "ipq"
     |   ## Introduction prose paragraph, right aligned
       "ipr"
-    |   ## Introduction prose paragraph, centred
-      "ipc"
     |   ## Introduction prose paragraph
       "ip"
     |   ## Introduction poetry text, level 1 (if multiple levels)


### PR DESCRIPTION
The style is already present at line 500 ("Introduction Inscription (paragraph text centered)").