### PR TITLE
Fix OtherPara "sts" style comment

### DIFF
--- a/grammar/usx.rnc
+++ b/grammar/usx.rnc
@@ -743,7 +743,7 @@ OtherPara.para.style.enum = (
       "k1"
     |   ## Concordance main entry text or keyword, level 2
       "k2"
-    |   ## Remark
+    |   ## Status
       "sts"
     |    ## Remark
       "rem"


### PR DESCRIPTION
Switched to the same comment as in `Header.para.style.enum`.